### PR TITLE
fix: remove duplicate renderCart call for invalid items

### DIFF
--- a/public/cart.js
+++ b/public/cart.js
@@ -41,8 +41,6 @@ try {
   isClearing = false;
 }
 return await renderCart();
-
-  return await renderCart();
 }
 
     console.log("🎯 Перевірка умов:");


### PR DESCRIPTION
## Summary
- prevent duplicate renderCart invocation when invalid cart items are detected

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b8208d4a4832bb7c42b0b7995e6ce