### PR TITLE
feat: remove items from cart

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,31 @@ app.post("/add-to-cart", (req, res) => {
   });
 });
 
+// ❌ Видалити товар з корзини
+app.post("/remove-from-cart", (req, res) => {
+  const { productId } = req.body;
+
+  if (!productId) {
+    return res.status(400).json({ error: "Product ID is required" });
+  }
+
+  if (!req.session.cart) {
+    req.session.cart = [];
+  }
+
+  req.session.cart = req.session.cart.filter(
+    item => item.id !== productId && item._id !== productId
+  );
+
+  req.session.save(err => {
+    if (err) {
+      console.error("❌ Помилка збереження сесії:", err);
+      return res.status(500).json({ error: "Session save failed" });
+    }
+    res.json({ success: true });
+  });
+});
+
 // 📦 Отримати корзину
 app.get("/get-cart", (req, res) => {
   res.json(req.session.cart || []);

--- a/public/cart.js
+++ b/public/cart.js
@@ -109,8 +109,10 @@ return await renderCart();
     document.querySelectorAll(".remove-btn").forEach(btn => {
       btn.addEventListener("click", async (e) => {
         const id = e.target.getAttribute("data-id");
-        const response = await fetch(`/remove-from-cart?id=${id}`, {
-          method: "POST"
+        const response = await fetch('/remove-from-cart', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ productId: id })
         });
         if (response.ok) {
           await renderCart(); // 🔁 Оновлюємо без перезавантаження


### PR DESCRIPTION
## Summary
- add `/remove-from-cart` endpoint to drop items by product id from session cart
- send product id in body when removing item on client side

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b82049034832b9b33384ab8679641