### PR TITLE
Disable checkout button when cart is empty

### DIFF
--- a/public/cart.js
+++ b/public/cart.js
@@ -2,6 +2,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const cartItemsContainer = document.getElementById("cart-items");
   const totalDisplay = document.getElementById("cart-total");
   const emptyMsg = document.getElementById("empty-cart-message");
+  const checkoutBtn = document.getElementById("checkout-button");
 
   const currencySymbols = {
     USD: "$", EUR: "€", UAH: "₴", PLN: "zł", AUD: "A$", CAD: "C$",
@@ -79,6 +80,9 @@ return await renderCart();
       emptyMsg.style.display = "block";
       cartItemsContainer.innerHTML = "";
       totalDisplay.innerText = `${currencySymbols[currentCurrency] || "$"}0.00`;
+      if (checkoutBtn) {
+        checkoutBtn.disabled = true;
+      }
       return;
     }
 
@@ -105,6 +109,9 @@ return await renderCart();
     });
 
     totalDisplay.innerText = `${currencySymbols[currentCurrency]}${total.toFixed(2)}`;
+    if (checkoutBtn) {
+      checkoutBtn.disabled = false;
+    }
 
     document.querySelectorAll(".remove-btn").forEach(btn => {
       btn.addEventListener("click", async (e) => {


### PR DESCRIPTION
## Summary
- prevent navigating to payment when cart has no items by disabling checkout button
- re-enable button when valid items are present

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5784aad40832baae774bc5b7d3e33