### PR TITLE
Integrate LiqPay payments and deliver codes via email

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ require("dotenv").config();
 const app = express();
 
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 const session = require("express-session");
 const MongoStore = require("connect-mongo");
 

--- a/routers/order.js
+++ b/routers/order.js
@@ -1,4 +1,8 @@
 const express = require("express");
+const crypto = require("crypto");
+const base64 = require("base-64");
+const nodemailer = require("nodemailer");
+
 const router = express.Router();
 
 // Валідація email
@@ -6,6 +10,52 @@ const validateEmail = (email) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 };
+
+const {
+  LIQPAY_PUBLIC_KEY,
+  LIQPAY_PRIVATE_KEY,
+  SMTP_HOST,
+  SMTP_PORT,
+  SMTP_USER,
+  SMTP_PASS,
+  BASE_URL
+} = process.env;
+
+const transporter = nodemailer.createTransport({
+  host: SMTP_HOST,
+  port: Number(SMTP_PORT) || 465,
+  secure: true,
+  auth: {
+    user: SMTP_USER,
+    pass: SMTP_PASS
+  }
+});
+
+function generateLiqPaySignature(data) {
+  return crypto
+    .createHash("sha1")
+    .update(LIQPAY_PRIVATE_KEY + data + LIQPAY_PRIVATE_KEY)
+    .digest("base64");
+}
+
+function createLiqPayData(params) {
+  const data = base64.encode(JSON.stringify(params));
+  const signature = generateLiqPaySignature(data);
+  return { data, signature };
+}
+
+function generateCode() {
+  return crypto.randomBytes(8).toString("hex").toUpperCase();
+}
+
+async function sendCodeEmail(to, code) {
+  await transporter.sendMail({
+    from: SMTP_USER,
+    to,
+    subject: "Your purchase code",
+    text: `Thank you for your purchase. Your code: ${code}`
+  });
+}
 
 router.post("/", async (req, res) => {
   const { productId, email, quantity, name, price } = req.body;
@@ -19,6 +69,7 @@ router.post("/", async (req, res) => {
     return res.status(400).json({ error: "Invalid email format." });
   }
 
+  const orderId = crypto.randomUUID();
   const order = {
     productId,
     email,
@@ -27,19 +78,69 @@ router.post("/", async (req, res) => {
     price: parseFloat(price),
     status: "pending",
     createdAt: new Date(),
+    orderId
   };
 
   try {
-    const result = await req.db.collection("orders").insertOne(order);
-    console.log("✅ Order saved to DB:", result.insertedId);
+    await req.db.collection("orders").insertOne(order);
 
-    // 🔕 Тимчасово НЕ надсилаємо email
-    // Якщо потрібно, розкоментуй нижче і додай nodemailer + env
+    const serverUrl =
+      BASE_URL || `${req.protocol}://${req.get("host")}`;
 
-    res.status(201).json({ message: "Order saved!", orderId: result.insertedId });
+    const params = {
+      public_key: LIQPAY_PUBLIC_KEY,
+      version: "3",
+      action: "pay",
+      amount: order.price,
+      currency: "USD",
+      description: `Purchase ${name}`,
+      order_id: orderId,
+      server_url: `${serverUrl}/api/order/liqpay-callback`
+    };
+
+    const liqpay = createLiqPayData(params);
+
+    res
+      .status(201)
+      .json({ message: "Order saved!", orderId, liqpay });
   } catch (err) {
     console.error("❌ Order error:", err);
     res.status(500).json({ error: "Order processing failed." });
+  }
+});
+
+router.post("/liqpay-callback", async (req, res) => {
+  const { data, signature } = req.body;
+
+  try {
+    const expected = generateLiqPaySignature(data);
+    if (signature !== expected) {
+      return res.status(400).json({ error: "Invalid signature" });
+    }
+
+    const payment = JSON.parse(base64.decode(data));
+
+    if (payment.status === "success" || payment.status === "sandbox") {
+      const order = await req.db
+        .collection("orders")
+        .findOne({ orderId: payment.order_id });
+
+      if (order && order.status !== "paid") {
+        const code = generateCode();
+        await sendCodeEmail(order.email, code);
+        await req.db
+          .collection("orders")
+          .updateOne(
+            { orderId: order.orderId },
+            { $set: { status: "paid", code, paymentInfo: payment } }
+          );
+      }
+    }
+
+    res.json({ status: "ok" });
+  } catch (err) {
+    console.error("❌ LiqPay callback error:", err);
+    res.status(500).json({ error: "Callback processing failed." });
   }
 });
 


### PR DESCRIPTION
## Summary
- add URL-encoded body parsing for payment callbacks
- integrate LiqPay payment flow and send purchase code by email after success

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6f4de6b1c832baca310320d319692