### PR TITLE
Redirect checkout to LiqPay and send code after payment

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -106,13 +106,29 @@
 
           const result = await res.json();
 
-          if (res.ok && result.orderId) {
-            document.querySelector("main").innerHTML = `
-              <h1>✅ Дякуємо!</h1>
-              <p>Ваше замовлення прийнято.</p>
-              <p><strong>Order ID:</strong> ${result.orderId}</p>
-            `;
+          if (res.ok && result.liqpay) {
+            // Видаляємо суму з сесії та переходимо до LiqPay
             sessionStorage.removeItem("cartTotal");
+
+            const form = document.createElement("form");
+            form.method = "POST";
+            form.action = "https://www.liqpay.ua/api/3/checkout";
+            form.acceptCharset = "utf-8";
+
+            const dataInput = document.createElement("input");
+            dataInput.type = "hidden";
+            dataInput.name = "data";
+            dataInput.value = result.liqpay.data;
+            form.appendChild(dataInput);
+
+            const signatureInput = document.createElement("input");
+            signatureInput.type = "hidden";
+            signatureInput.name = "signature";
+            signatureInput.value = result.liqpay.signature;
+            form.appendChild(signatureInput);
+
+            document.body.appendChild(form);
+            form.submit();
           } else {
             alert("❌ Помилка створення замовлення");
           }

--- a/routers/order.js
+++ b/routers/order.js
@@ -95,7 +95,8 @@ router.post("/", async (req, res) => {
       currency: "USD",
       description: `Purchase ${name}`,
       order_id: orderId,
-      server_url: `${serverUrl}/api/order/liqpay-callback`
+      server_url: `${serverUrl}/api/order/liqpay-callback`,
+      result_url: `${serverUrl}/order-success.html`
     };
 
     const liqpay = createLiqPayData(params);


### PR DESCRIPTION
## Summary
- Redirect checkout form submissions to LiqPay using signed form data.
- Add LiqPay result URL for returning to order success page after payment.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a70251eb40832b98dab166ef0e4d55