### PR TITLE
Add 10% margin to API price responses

### DIFF
--- a/routers/bamboo.js
+++ b/routers/bamboo.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const axios = require("axios");
+const { addMarginToPrices } = require("../utils/priceMargin");
 
 const {
   BAMBOO_PROD_CLIENT_ID,
@@ -27,7 +28,8 @@ router.get("/", async (req, res) => {
 
     console.log("✅ Bamboo production catalog items:", response.data?.items?.length || 0);
 
-    res.json(response.data);
+    const dataWithMargin = addMarginToPrices(response.data);
+    res.json(dataWithMargin);
   } catch (error) {
     const err = error.response?.data || error.message;
     console.error("❌ Bamboo PRODUCTION fetch error:", err);

--- a/routers/productPage.js
+++ b/routers/productPage.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const axios = require("axios");
+const { addMarginToPrices } = require("../utils/priceMargin");
 
 const {
   BAMBOO_CLIENT_ID,
@@ -44,7 +45,8 @@ router.get("/api/:brand/:region?", async (req, res) => {
     });
 
     console.log("✅ Received Bamboo data. Count:", response.data.count);
-    res.json(response.data);
+    const dataWithMargin = addMarginToPrices(response.data);
+    res.json(dataWithMargin);
   } catch (error) {
     const err = error.response?.data || error.message;
     console.error("❌ Dynamic route error:", err);
@@ -81,7 +83,8 @@ router.get("/api/search", async (req, res) => {
     });
 
     console.log(`✅ Received Bamboo data. Count: ${response.data.count}`);
-    res.json(response.data);
+    const dataWithMargin = addMarginToPrices(response.data);
+    res.json(dataWithMargin);
   } catch (error) {
     const err = error.response?.data || error.message;
     console.error("❌ Search route error:", err);

--- a/routers/products.js
+++ b/routers/products.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const axios = require("axios");
 const crypto = require("crypto");
+const { addMarginToPrices } = require("../utils/priceMargin");
 
 const router = express.Router();
 
@@ -61,7 +62,8 @@ router.get("/", async (req, res) => {
       }
     );
 
-    res.json(response.data);
+    const dataWithMargin = addMarginToPrices(response.data);
+    res.json(dataWithMargin);
   } catch (error) {
     const errRes = error.response?.data || error.message;
     console.error("❌ Auth or fetch error:", errRes);

--- a/utils/priceMargin.js
+++ b/utils/priceMargin.js
@@ -1,0 +1,36 @@
+function addMarginToPriceValue(value, margin) {
+  if (typeof value === 'number') {
+    return Number((value * (1 + margin)).toFixed(2));
+  }
+  if (Array.isArray(value)) {
+    return value.map(v => addMarginToPriceValue(v, margin));
+  }
+  if (value && typeof value === 'object') {
+    const result = {};
+    for (const key in value) {
+      result[key] = addMarginToPriceValue(value[key], margin);
+    }
+    return result;
+  }
+  return value;
+}
+
+function addMarginToPrices(data, margin = 0.1) {
+  if (Array.isArray(data)) {
+    return data.map(item => addMarginToPrices(item, margin));
+  }
+  if (data && typeof data === 'object') {
+    const result = {};
+    for (const key in data) {
+      if (key.toLowerCase().includes('price')) {
+        result[key] = addMarginToPriceValue(data[key], margin);
+      } else {
+        result[key] = addMarginToPrices(data[key], margin);
+      }
+    }
+    return result;
+  }
+  return data;
+}
+
+module.exports = { addMarginToPrices };


### PR DESCRIPTION
## Summary
- add recursive helper to apply pricing margins
- apply 10% markup to prices returned from Giftery and Bamboo APIs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a731d6538c832ba856ab0dcdad1ae2