### PR TITLE
refactor: centralize colors with CSS variables

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,15 @@
+/* Define color variables */
+:root {
+  --color-primary: #543885;
+  --color-secondary: #fff;
+  --color-bg: #f7f5ff;
+  --color-text: #333;
+}
+
 /* 🔁 z-index для header */
 header {
-  background-color: #543885;
-  color: #fff;
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
   padding: 1rem 0;
   position: sticky;
   top: 0;
@@ -10,9 +18,9 @@ header {
 
 body {
   margin: 0;
-  font-family: "Segoe UI", sans-serif;
-  background-color: #f7f5ff;
-  color: #333;
+  font-family: "Inter", sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .container {
@@ -33,7 +41,7 @@ body {
   display: flex;
   align-items: center;
   text-decoration: none;
-  color: #fff;
+  color: var(--color-secondary);
 }
 
 .logo img {
@@ -45,7 +53,7 @@ body {
   margin-left: auto;
   margin-right: auto;
   display: flex;
-  background: #fff;
+  background: var(--color-secondary);
   border-radius: 5px;
   overflow: hidden;
   max-width: 400px;
@@ -61,8 +69,8 @@ body {
 }
 
 .header-search button {
-  background: #543885;
-  color: white;
+  background: var(--color-primary);
+  color: var(--color-secondary);
   border: none;
   padding: 0 1rem;
   cursor: pointer;
@@ -86,7 +94,7 @@ main {
 }
 
 .category-card {
-  background: white;
+  background: var(--color-secondary);
   border-radius: 10px;
   text-align: center;
   padding: 1rem;
@@ -100,7 +108,7 @@ main {
 
 .category-card:hover {
   background-color: #6a0dad;
-  color: white;
+  color: var(--color-secondary);
 }
 
 .category-card img {
@@ -132,18 +140,18 @@ footer {
 }
 
 .cart-button {
-  background: #543885;
+  background: var(--color-primary);
   padding: 0.5rem 1rem;
   border-radius: 5px;
   text-decoration: none;
-  color: #543885;
+  color: var(--color-primary);
   font-weight: bold;
-  border: 2px solid #543885;
+  border: 2px solid var(--color-primary);
 }
 
 .cart-button:hover {
-  background: #543885;
-  color: #543885;
+  background: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .cart-icon {
@@ -163,7 +171,7 @@ footer {
   margin-top: 2rem;
   padding: 0.8rem 2rem;
   background: #6a0dad;
-  color: white;
+  color: var(--color-secondary);
   border: none;
   border-radius: 5px;
   font-size: 1rem;
@@ -196,7 +204,7 @@ footer {
 }
 
 .card-row .card {
-  background: white;
+  background: var(--color-secondary);
   color: black;
   padding: 0.5rem;
   border-radius: 10px;
@@ -251,8 +259,8 @@ footer {
 }
 
 .dropbtn {
-  background-color: #543885;
-  color: white;
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
   border: none;
   padding: 10px 16px;
   border-radius: 6px;
@@ -265,7 +273,7 @@ footer {
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: white;
+  background-color: var(--color-secondary);
   min-width: 170px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   border-radius: 8px;
@@ -277,12 +285,12 @@ footer {
   display: block;
   padding: 0.5rem 0;
   text-decoration: none;
-  color: #333;
+  color: var(--color-text);
   font-weight: 500;
 }
 
 .dropdown-content a:hover {
-  color: #543885;
+  color: var(--color-primary);
 }
 .dropdown-content.show {
   display: block;
@@ -310,7 +318,7 @@ footer {
   top: -6px;
   right: -6px;
   background: red;
-  color: white;
+  color: var(--color-secondary);
   font-size: 0.7rem;
   padding: 2px 6px;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- add global CSS variables for primary, secondary, background, and text colors
- replace hardcoded colors in header, buttons, and dropdown with variables
- update base font stack to use "Inter"

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acb57c075c832ba06996f089254bda