### PR TITLE
Build frontend to root dist

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     port: 3000
   },
   build: {
-    outDir: 'dist',
+    outDir: '../dist',
     emptyOutDir: true
   }
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "engines": { "node": ">=18" },
   "scripts": {
-    "build:frontend": "cd frontend && npm ci && npm run build && cp -R dist ../dist",
+    "build:frontend": "cd frontend && npm ci && npm run build",
     "build": "npm run build:frontend",
     "start": "node server.mjs"
   },


### PR DESCRIPTION
## Summary
- configure Vite build to emit frontend assets into the repository root `dist` folder
- simplify build script now that assets are written directly to `dist`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68add9ac2294832bb3573ac94c76ce4c