### PR TITLE
Fix frontend build path for deployment

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,11 @@ export default defineConfig({
     port: 3000
   },
   build: {
-    outDir: '../dist',
+    // Output the production build inside the frontend directory so that the
+    // Express server can serve from `frontend/dist`. Previously the build
+    // generated files one level up ("../dist"), but the server now expects
+    // them in this local directory.
+    outDir: 'dist',
     emptyOutDir: true
   }
 });

--- a/server.mjs
+++ b/server.mjs
@@ -8,14 +8,21 @@ const __dirname = path.dirname(__filename);
 const app = express();
 
 // static files from Vite build
-app.use(express.static(path.join(__dirname, "dist")));
+// The frontend is located in the `frontend` directory and its production
+// build output lives in `frontend/dist`. In production (Render) the build
+// command runs `npm run build` which generates these files, so the express
+// server needs to serve from that location. Previously the server looked for
+// `dist` in the project root which does not exist, resulting in `ENOENT` when
+// trying to serve `index.html`.
+const distPath = path.join(__dirname, "frontend", "dist");
+app.use(express.static(distPath));
 
 // simple healthcheck for Render
 app.get("/healthz", (_req, res) => res.status(200).send("OK"));
 
 // SPA fallback (React Router)
 app.get("*", (_req, res) => {
-  res.sendFile(path.join(__dirname, "dist", "index.html"));
+  res.sendFile(path.join(distPath, "index.html"));
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- Serve static files from `frontend/dist` so the Node server can find the built frontend
- Adjust Vite build output to generate files in `frontend/dist` for the server to serve

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node server.mjs &` and `curl -I http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68addc0fdde8832b880aea05048e92bc