### PR TITLE
chore: add Render deployment configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,9 @@ services:
     name: digi-backend
     env: node
     plan: free
-    buildCommand: npm --prefix frontend install --no-audit --no-fund --registry=https://registry.npmjs.org && npm --prefix frontend run build
+    buildCommand: >
+      npm --prefix frontend install --no-audit --no-fund --registry=https://registry.npmjs.org
+      && npm --prefix frontend run build
     startCommand: node server.mjs
     autoDeploy: true
     healthCheckPath: /healthz


### PR DESCRIPTION
## Summary
- define Render service config for deploying the Node app and building the frontend

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adf542116c832b8c51c281cd91f835