### PR TITLE
feat: redesign header/footer and add cart support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import TravelPage from "./components/TravelPage";
 import AboutUsPage from "./components/AboutUsPage";
 import ContactPage from "./components/ContactPage";
 import FAQPage from "./components/FAQPage";
+import CartPage from "./components/CartPage";
 export default function App(){
   return (
     <BrowserRouter>
@@ -27,6 +28,7 @@ export default function App(){
           <Route path="/about" element={<AboutUsPage/>}/>
           <Route path="/contact" element={<ContactPage/>}/>
           <Route path="/faq" element={<FAQPage/>}/>
+          <Route path="/cart" element={<CartPage/>}/>
         </Routes>
       </main>
       <Footer/>

--- a/frontend/src/components/CartPage.tsx
+++ b/frontend/src/components/CartPage.tsx
@@ -1,0 +1,22 @@
+import { getCart, setCart } from "../store/cart";
+export default function CartPage(){
+  const items=getCart();
+  const remove=(i:number)=>{const arr=getCart();arr.splice(i,1);setCart(arr);location.reload();};
+  return (
+    <div className="container">
+      <h2 className="section-title">Your Cart</h2>
+      {items.length===0 ? <p>Cart is empty.</p> :
+        items.map((it,idx)=>(
+          <div className="card" key={idx} style={{display:"flex",alignItems:"center",gap:12}}>
+            {it.img && <img src={it.img} alt="" style={{width:80,height:60,objectFit:"cover"}}/>}
+            <div style={{flex:1}}>
+              <div className="name">{it.name}</div>
+              <div className="price">{it.price}</div>
+            </div>
+            <button className="btn" onClick={()=>remove(idx)}>Remove</button>
+          </div>
+        ))
+      }
+    </div>
+  );
+}

--- a/frontend/src/components/CategoryCard.tsx
+++ b/frontend/src/components/CategoryCard.tsx
@@ -2,12 +2,12 @@ import { Link } from "react-router-dom";
 export default function CategoryCard({icon,title,note,href}:{icon:string;title:string;note:string;href:string;}){
   return (
     <div className="cat-card">
+      <Link to={href} className="stretched"></Link>
       <div className="cat-header">
         <span className="cat-icon"><img src={icon} alt={title} width={24} height={24}/></span>
         <div>
           <div className="cat-title">{title}</div>
           <div className="cat-note">{note}</div>
-          <Link className="cat-link" to={href}>Browse {title.toLowerCase()} cards</Link>
         </div>
       </div>
     </div>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,14 +1,18 @@
-import { NavLink } from 'react-router-dom';
-
-export default function Footer() {
+import { Link } from "react-router-dom";
+export default function Footer(){
   return (
-    <footer>
-      <div className="footer-links">
-        <NavLink to="/about">About</NavLink>
-        <NavLink to="/contact">Contact</NavLink>
-        <NavLink to="/faq">FAQ</NavLink>
+    <footer style={{background:"#fff",borderTop:"1px solid var(--card-border)",marginTop:40}}>
+      <div className="container" style={{padding:"28px 0", display:"grid", gap:12}}>
+        <nav style={{display:"flex",gap:16,flexWrap:"wrap"}}>
+          <Link to="/about">About</Link>
+          <Link to="/contact">Contact</Link>
+          <Link to="/faq">FAQ</Link>
+          <Link to="/terms">Terms</Link>
+          <Link to="/privacy">Privacy</Link>
+          <Link to="/refunds">Refund Policy</Link>
+        </nav>
+        <div style={{color:"var(--muted)",fontSize:13, paddingTop:8}}>© 2025 DigiGames</div>
       </div>
-      <p>&copy; {new Date().getFullYear()} DigiGames</p>
     </footer>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,25 +1,32 @@
 import { Link, NavLink } from "react-router-dom";
+import GlobeIcon from "./icons/GlobeIcon";
+import CurrencyIcon from "./icons/CurrencyIcon";
+import CartIcon from "./icons/CartIcon";
 
 export default function Header(){
   return (
     <header className="topbar">
       <div className="container topbar-inner">
         <Link to="/" className="brand">DigiGames</Link>
+
         <div className="search">
-          <input placeholder="Search gift cards..." />
+          <input placeholder="Search gift cards..." aria-label="Search gift cards" />
         </div>
-        <nav className="topnav">
-          <NavLink to="/" end>Home</NavLink>
-          <NavLink to="/gaming">Gaming</NavLink>
-          <NavLink to="/streaming">Streaming</NavLink>
-          <NavLink to="/shopping">Shopping</NavLink>
-          <NavLink to="/music">Music</NavLink>
-          <NavLink to="/fooddrink">Food & Drink</NavLink>
-          <NavLink to="/travel">Travel</NavLink>
-          <NavLink to="/about">About</NavLink>
-          <NavLink to="/contact">Contact</NavLink>
-          <NavLink to="/faq">FAQ</NavLink>
+
+        <nav className="topnav" aria-label="Top">
+          <button className="icon-btn" aria-label="Language"><GlobeIcon/></button>
+          <button className="icon-btn" aria-label="Currency"><CurrencyIcon/></button>
+          <Link to="/cart" className="icon-btn" aria-label="Cart"><CartIcon/></Link>
         </nav>
+      </div>
+      <div className="container" style={{display:"flex",gap:12,alignItems:"center",height:44}}>
+        <NavLink to="/" end>Home</NavLink>
+        <NavLink to="/gaming">Gaming</NavLink>
+        <NavLink to="/streaming">Streaming</NavLink>
+        <NavLink to="/shopping">Shopping</NavLink>
+        <NavLink to="/music">Music</NavLink>
+        <NavLink to="/fooddrink">Food & Drink</NavLink>
+        <NavLink to="/travel">Travel</NavLink>
       </div>
     </header>
   );

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -1,4 +1,5 @@
 import CategoryCard from "./CategoryCard";
+import { getCart, setCart } from "../store/cart";
 
 const categories = [
   { title:"Gaming",      note:"120+ cards", icon:"/assets/icons/gaming.svg",    href:"/gaming" },
@@ -14,6 +15,11 @@ const featured = [
   { name:"Netflix Gift Card",           price:"$25.00", rating:"4.6", img:"/assets/images/netflix.webp" },
   { name:"Steam Wallet Code",           price:"$20.00", rating:"4.9", img:"/assets/images/steam.webp" },
 ];
+
+function addToCart(item:any){
+  const cur=getCart(); cur.push({name:item.name,price:item.price,img:item.img}); setCart(cur);
+  alert("Added to cart");
+}
 
 export default function HomePage(){
   return (
@@ -31,6 +37,7 @@ export default function HomePage(){
             <div className="name">{f.name}</div>
             <div className="price">{f.price}</div>
             <div className="rating">Rating: {f.rating}</div>
+            <button className="btn" onClick={()=>addToCart(f)}>Add to cart</button>
           </div>
         ))}
       </div>

--- a/frontend/src/components/icons/CartIcon.tsx
+++ b/frontend/src/components/icons/CartIcon.tsx
@@ -1,0 +1,1 @@
+export default function CartIcon({size=18}:{size?:number}){return(<svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 12.39A2 2 0 0 0 9.62 15H19a2 2 0 0 0 2-1.72l1-7H6"/></svg>);}

--- a/frontend/src/components/icons/CurrencyIcon.tsx
+++ b/frontend/src/components/icons/CurrencyIcon.tsx
@@ -1,0 +1,1 @@
+export default function CurrencyIcon({size=18}:{size?:number}){return(<svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 1v22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7H14a3.5 3.5 0 0 1 0 7H6"/></svg>);}

--- a/frontend/src/components/icons/GlobeIcon.tsx
+++ b/frontend/src/components/icons/GlobeIcon.tsx
@@ -1,0 +1,1 @@
+export default function GlobeIcon(props:{size?:number}){const s=props.size??18;return (<svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 0 20M12 2a15.3 15.3 0 0 0 0 20"/></svg>);}

--- a/frontend/src/store/cart.ts
+++ b/frontend/src/store/cart.ts
@@ -1,0 +1,4 @@
+export type Item={name:string,price:string,img?:string};
+const key="dg_cart";
+export const getCart=():Item[]=>{try{return JSON.parse(localStorage.getItem(key)||"[]")}catch{return []}};
+export const setCart=(v:Item[])=>localStorage.setItem(key,JSON.stringify(v));

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -33,19 +33,19 @@ body{
   background:#fff;
 }
 
+.icon-btn{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border:1px solid var(--card-border);border-radius:10px;background:#fff;color:#374151;cursor:pointer}
+.icon-btn:hover{background:#F3F4F6}
+
+.btn{border:1px solid var(--card-border);background:#fff;border-radius:10px;padding:8px 12px;font-weight:600;cursor:pointer}
+.btn:hover{background:#F3F4F6}
+
 .grid{display:grid;gap:16px}
 .grid.categories{grid-template-columns:repeat(1,1fr)}
 @media(min-width:768px){.grid.categories{grid-template-columns:repeat(3,1fr)}}
 
 .cat-card{
   background:var(--card-bg);border:1px solid var(--card-border);border-radius:var(--radius);
-  box-shadow:var(--shadow);padding:20px 22px;
-  transition:transform .15s,box-shadow .15s,border-color .15s;
-}
-.cat-card:hover{
-  transform:translateY(-2px);
-  box-shadow:0 16px 42px rgba(17,24,39,.10);
-  border-color:#D1D5DB;
+  box-shadow:var(--shadow);padding:20px 22px;position:relative;
 }
 .cat-header{display:flex;align-items:center;gap:12px}
 .cat-icon{
@@ -54,11 +54,6 @@ body{
 }
 .cat-title{margin:6px 0 4px;font-weight:600}
 .cat-note{color:var(--muted);font-size:13px;margin-bottom:6px}
-.cat-link{
-  display:inline-flex;align-items:center;gap:6px;
-  color:var(--brand);text-decoration:none;font-weight:500;font-size:13.5px;
-}
-.cat-link::after{content:"→"}
 
 .grid.featured{grid-template-columns:repeat(1,1fr)}
 @media(min-width:768px){.grid.featured{grid-template-columns:repeat(3,1fr)}}
@@ -71,3 +66,13 @@ body{
 }
 .card .name{font-weight:600;margin:10px 0 6px}
 .card .price,.card .rating{color:var(--muted);font-size:14px}
+
+.cat-card, .card { transition: transform .18s ease, box-shadow .18s ease; }
+.cat-card:hover, .card:hover { transform: translateY(-4px); box-shadow: 0 18px 46px rgba(17,24,39,.12); }
+.cat-card:focus-within, .card:focus-within { outline: 2px solid var(--brand); outline-offset: 2px; }
+
+.stretched{ position: static; }
+.cat-card .stretched{ position:absolute; inset:0; opacity:0; }
+
+a{ color:var(--brand); text-decoration:none }
+a:hover{ text-decoration:underline }


### PR DESCRIPTION
## Summary
- add SVG icon components and simplify header with language, currency, and cart controls
- move informational links to new footer
- add localStorage-backed cart with buttons on featured items

## Testing
- `npm --prefix frontend run build` *(fails: vite not found)*
- `npm --prefix frontend install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68aec5725524832b984acaca680c2cfb