### PR TITLE
Add footer and cart controls

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,18 +1,57 @@
 import { Link } from "react-router-dom";
+
 export default function Footer(){
   return (
-    <footer style={{background:"#fff",borderTop:"1px solid var(--card-border)",marginTop:40}}>
-      <div className="container" style={{padding:"28px 0", display:"grid", gap:12}}>
-        <nav style={{display:"flex",gap:16,flexWrap:"wrap"}}>
-          <Link to="/about">About</Link>
-          <Link to="/contact">Contact</Link>
-          <Link to="/faq">FAQ</Link>
-          <Link to="/terms">Terms</Link>
-          <Link to="/privacy">Privacy</Link>
-          <Link to="/refunds">Refund Policy</Link>
-        </nav>
-        <div style={{color:"var(--muted)",fontSize:13, paddingTop:8}}>© 2025 DigiGames</div>
-      </div>
+    <footer className="footer">
+      <section className="nl">
+        <div className="container nl-inner">
+          <div className="nl-title">Stay Updated</div>
+          <div className="nl-sub">Get the latest gaming deals and new gift cards delivered to your inbox</div>
+          <form className="nl-form" onSubmit={(e)=>e.preventDefault()}>
+            <input placeholder="Enter your email" type="email" required/>
+            <button aria-label="Subscribe">✉️</button>
+          </form>
+        </div>
+      </section>
+
+      <section className="container footer-grid">
+        <div>
+          <div className="f-brand">DigiGames</div>
+          <p className="muted">Your trusted marketplace for digital gift cards. Fast, secure, and reliable for customers worldwide.</p>
+          <div className="soc">
+            <a href="#" aria-label="X">𝕏</a><a href="#" aria-label="Instagram">◎</a><a href="#" aria-label="YouTube">►</a>
+          </div>
+        </div>
+        <div>
+          <div className="f-title">Quick Links</div>
+          <nav className="f-list">
+            <Link to="/browse">Browse Cards</Link>
+            <Link to="/how-it-works">How It Works</Link>
+            <Link to="/about">About Us</Link>
+            <Link to="/contact">Contact</Link>
+          </nav>
+        </div>
+        <div>
+          <div className="f-title">Categories</div>
+          <nav className="f-list">
+            <Link to="/gaming">Gaming</Link>
+            <Link to="/streaming">Streaming</Link>
+            <Link to="/shopping">Shopping</Link>
+            <Link to="/music">Music</Link>
+          </nav>
+        </div>
+        <div>
+          <div className="f-title">Support</div>
+          <nav className="f-list">
+            <Link to="/help">Help Center</Link>
+            <Link to="/privacy">Privacy Policy</Link>
+            <Link to="/terms">Terms of Service</Link>
+            <Link to="/refunds">Refund Policy</Link>
+          </nav>
+        </div>
+      </section>
+
+      <div className="container f-copy">© 2025 DigiGames</div>
     </footer>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,25 +1,37 @@
 import { Link, NavLink } from "react-router-dom";
-import GlobeIcon from "./icons/GlobeIcon";
-import CurrencyIcon from "./icons/CurrencyIcon";
 import CartIcon from "./icons/CartIcon";
+import { LanguageMenu, CurrencyMenu } from "./menus/LanguageCurrencyMenu";
+import { useEffect, useState } from "react";
+import { totalCount } from "../store/cart";
 
 export default function Header(){
+  const [lang,setLang] = useState("EN");
+  const [cur,setCur] = useState("USD");
+  const [count,setCount] = useState(0);
+
+  useEffect(()=>{
+    setCount(totalCount());
+    const i = setInterval(()=>setCount(totalCount()), 800); // simple polling localStorage
+    return ()=> clearInterval(i);
+  },[]);
+
   return (
     <header className="topbar">
       <div className="container topbar-inner">
         <Link to="/" className="brand">DigiGames</Link>
-
-        <div className="search">
-          <input placeholder="Search gift cards..." aria-label="Search gift cards" />
-        </div>
-
-        <nav className="topnav" aria-label="Top">
-          <button className="icon-btn" aria-label="Language"><GlobeIcon/></button>
-          <button className="icon-btn" aria-label="Currency"><CurrencyIcon/></button>
-          <Link to="/cart" className="icon-btn" aria-label="Cart"><CartIcon/></Link>
+        <div className="search"><input placeholder="Search gift cards..." /></div>
+        <nav className="topnav" aria-label="Actions">
+          <LanguageMenu value={lang} onChange={setLang}/>
+          <CurrencyMenu value={cur} onChange={setCur}/>
+          <Link to="/cart" className="icon-btn badge" aria-label="Cart">
+            <CartIcon/>
+            {count>0 && <span className="badge-dot">{count}</span>}
+          </Link>
         </nav>
       </div>
-      <div className="container" style={{display:"flex",gap:12,alignItems:"center",height:44}}>
+
+      {/* lower navigation row only categories */}
+      <div className="container topcats">
         <NavLink to="/" end>Home</NavLink>
         <NavLink to="/gaming">Gaming</NavLink>
         <NavLink to="/streaming">Streaming</NavLink>

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -1,5 +1,5 @@
 import CategoryCard from "./CategoryCard";
-import { getCart, setCart } from "../store/cart";
+import { addToCart as add, removeFromCart, inCart, qtyOf, setQty } from "../store/cart";
 
 const categories = [
   { title:"Gaming",      note:"120+ cards", icon:"/assets/icons/gaming.svg",    href:"/gaming" },
@@ -11,14 +11,23 @@ const categories = [
 ];
 
 const featured = [
-  { name:"PlayStation Store Gift Card", price:"$50.00", rating:"4.8", img:"/assets/images/ps.webp" },
-  { name:"Netflix Gift Card",           price:"$25.00", rating:"4.6", img:"/assets/images/netflix.webp" },
-  { name:"Steam Wallet Code",           price:"$20.00", rating:"4.9", img:"/assets/images/steam.webp" },
+  { id:"ps", name:"PlayStation Store Gift Card", price:"$50.00", rating:"4.8", img:"/assets/images/ps.webp" },
+  { id:"netflix", name:"Netflix Gift Card",           price:"$25.00", rating:"4.6", img:"/assets/images/netflix.webp" },
+  { id:"steam", name:"Steam Wallet Code",           price:"$20.00", rating:"4.9", img:"/assets/images/steam.webp" },
 ];
 
-function addToCart(item:any){
-  const cur=getCart(); cur.push({name:item.name,price:item.price,img:item.img}); setCart(cur);
-  alert("Added to cart");
+function ItemControls({id}:{id:string}){
+  const added = inCart(id);
+  const qty = qtyOf(id);
+  if (!added) return <button className="btn primary" onClick={()=>add({id, name:"", price:0})}>Add to cart</button>;
+  return (
+    <div className="qtyrow">
+      <button className="btn sm" onClick={()=> setQty(id, Math.max(1, qty-1))}>–</button>
+      <span className="qty">{qty}</span>
+      <button className="btn sm" onClick={()=> setQty(id, qty+1)}>+</button>
+      <button className="btn danger" onClick={()=> removeFromCart(id)}>Remove from Cart</button>
+    </div>
+  );
 }
 
 export default function HomePage(){
@@ -32,12 +41,12 @@ export default function HomePage(){
       <h2 className="section-title" style={{marginTop:32}}>Featured Gift Cards</h2>
       <div className="grid featured">
         {featured.map(f=>(
-          <div className="card" key={f.name}>
+          <div className="card" key={f.id}>
             <img src={f.img} alt={f.name} loading="lazy"/>
             <div className="name">{f.name}</div>
             <div className="price">{f.price}</div>
             <div className="rating">Rating: {f.rating}</div>
-            <button className="btn" onClick={()=>addToCart(f)}>Add to cart</button>
+            <ItemControls id={f.id} />
           </div>
         ))}
       </div>

--- a/frontend/src/components/menus/LanguageCurrencyMenu.tsx
+++ b/frontend/src/components/menus/LanguageCurrencyMenu.tsx
@@ -1,0 +1,38 @@
+import { useState, useEffect, useRef } from "react";
+
+const LANGS = ["EN","UA","PL","DE"];
+const CURRENCIES = ["USD","EUR","UAH","CAD","AUD","PLN"];
+
+function useDropdown(){
+  const [open,setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(()=>{
+    const onClick = (e:MouseEvent)=> { if(ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
+    window.addEventListener("click", onClick);
+    return ()=> window.removeEventListener("click", onClick);
+  },[]);
+  return { open, setOpen, ref };
+}
+
+export function LanguageMenu({value,onChange}:{value:string;onChange:(v:string)=>void}){
+  const {open,setOpen,ref} = useDropdown();
+  return (
+    <div className="dd" ref={ref}>
+      <button className="icon-btn" onClick={()=>setOpen(!open)} aria-label="Language">{value}</button>
+      {open && <div className="dd-menu">{LANGS.map(l=>(
+        <button key={l} onClick={()=>{onChange(l); setOpen(false);}}>{l}</button>
+      ))}</div>}
+    </div>
+  );
+}
+export function CurrencyMenu({value,onChange}:{value:string;onChange:(v:string)=>void}){
+  const {open,setOpen,ref} = useDropdown();
+  return (
+    <div className="dd" ref={ref}>
+      <button className="icon-btn" onClick={()=>setOpen(!open)} aria-label="Currency">{value}</button>
+      {open && <div className="dd-menu">{CURRENCIES.map(c=>(
+        <button key={c} onClick={()=>{onChange(c); setOpen(false);}}>{c}</button>
+      ))}</div>}
+    </div>
+  );
+}

--- a/frontend/src/store/cart.ts
+++ b/frontend/src/store/cart.ts
@@ -1,4 +1,29 @@
-export type Item={name:string,price:string,img?:string};
-const key="dg_cart";
-export const getCart=():Item[]=>{try{return JSON.parse(localStorage.getItem(key)||"[]")}catch{return []}};
-export const setCart=(v:Item[])=>localStorage.setItem(key,JSON.stringify(v));
+export type Item = { id: string; name: string; price: number; img?: string; qty: number };
+const KEY = "dg_cart_v1";
+
+export const getCart = (): Item[] => {
+  try { return JSON.parse(localStorage.getItem(KEY) || "[]"); } catch { return []; }
+};
+export const setCart = (items: Item[]) => localStorage.setItem(KEY, JSON.stringify(items));
+
+export const addToCart = (item: Omit<Item,"qty"> & { qty?: number }) => {
+  const cart = getCart();
+  const idx = cart.findIndex(i => i.id === item.id);
+  if (idx === -1) cart.push({ ...item, qty: item.qty ?? 1 });
+  else cart[idx].qty += item.qty ?? 1;
+  setCart(cart);
+};
+export const removeFromCart = (id: string) => {
+  const cart = getCart().filter(i => i.id !== id);
+  setCart(cart);
+};
+export const setQty = (id: string, qty: number) => {
+  const cart = getCart();
+  const it = cart.find(i => i.id === id);
+  if (!it) return;
+  it.qty = Math.max(1, qty);
+  setCart(cart);
+};
+export const inCart = (id: string) => getCart().some(i => i.id === id);
+export const qtyOf = (id: string) => getCart().find(i => i.id === id)?.qty ?? 0;
+export const totalCount = () => getCart().reduce((s,i)=>s+i.qty,0);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -76,3 +76,56 @@ body{
 
 a{ color:var(--brand); text-decoration:none }
 a:hover{ text-decoration:underline }
+
+/* dropdowns */
+.dd{ position:relative }
+.dd-menu{
+  position:absolute; top:44px; right:0; background:#fff; border:1px solid var(--card-border);
+  border-radius:12px; box-shadow:var(--shadow); padding:6px; min-width:120px; z-index:20;
+  display:grid; gap:4px;
+}
+.dd-menu button{ background:#fff; border:0; text-align:left; padding:8px 10px; border-radius:8px; cursor:pointer }
+.dd-menu button:hover{ background:#F3F4F6 }
+
+/* cart badge */
+.badge{ position:relative }
+.badge-dot{
+  position:absolute; top:-6px; right:-6px; background:#111; color:#fff; font-size:11px;
+  min-width:18px; height:18px; display:grid; place-items:center; border-radius:999px; padding:0 4px;
+}
+
+/* second row of header categories */
+.topcats{ display:flex; gap:12px; align-items:center; height:44px; }
+.topcats a{ color:#4b5563; text-decoration:none; padding:8px 10px; border-radius:8px }
+.topcats a:hover{ background:#F3F4F6 }
+
+/* buttons */
+.btn{ border:1px solid var(--card-border); background:#fff; border-radius:10px; padding:8px 12px; font-weight:600; cursor:pointer }
+.btn:hover{ background:#F3F4F6 }
+.btn.primary{ background:#0B0B1C; color:#fff; border-color:#0B0B1C }
+.btn.primary:hover{ opacity:.92 }
+.btn.danger{ background:#C0262D; color:#fff; border-color:#C0262D }
+.btn.danger:hover{ filter:brightness(.96) }
+.btn.sm{ padding:6px 10px }
+.qtyrow{ display:flex; align-items:center; gap:8px; margin-top:8px }
+.qty{ min-width:20px; text-align:center }
+
+/* footer */
+.footer{ background:#0B0B1C; color:#E5E7EB; margin-top:48px }
+.nl{ background:#0B0B1C; border-top:1px solid #15162b; border-bottom:1px solid #15162b }
+.nl-inner{ padding:40px 0; display:grid; gap:10px; text-align:center }
+.nl-title{ font-size:22px; font-weight:700 }
+.nl-sub{ color:#9CA3AF; font-size:14px }
+.nl-form{ margin:12px auto 0; display:flex; gap:8px; width:min(520px,100%) }
+.nl-form input{ flex:1; border:1px solid #2b2f52; background:#0f1024; color:#fff; border-radius:12px; padding:12px }
+.nl-form button{ width:44px; border-radius:12px; border:1px solid #2b2f52; background:#111536; color:#fff; cursor:pointer }
+.footer-grid{ padding:36px 0; display:grid; gap:24px; grid-template-columns: repeat(1,1fr) }
+@media(min-width:900px){ .footer-grid{ grid-template-columns: 2fr 1fr 1fr 1fr } }
+.f-brand{ font-weight:700; font-size:18px; margin-bottom:8px }
+.f-title{ font-weight:600; margin-bottom:8px }
+.f-list{ display:grid; gap:6px }
+.f-list a{ color:#D1D5DB; text-decoration:none }
+.f-list a:hover{ text-decoration:underline }
+.soc{ display:flex; gap:10px; margin-top:8px }
+.f-copy{ color:#9CA3AF; font-size:13px; padding:14px 0; border-top:1px solid #15162b }
+


### PR DESCRIPTION
## Summary
- implement full newsletter footer with link columns
- add language/currency dropdown menus and cart badge
- enable cart item quantities in featured cards

## Testing
- `npm --prefix frontend run build` *(fails: vite not found)*
- `npm --prefix frontend install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda7a23dc832b8b2e35223abbb540