### PR TITLE
feat: add catalog category pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage"; // Figma Home
-import GamingPage from "./components/GamingPage";
-import StreamingPage from "./components/StreamingPage";
-import ShoppingPage from "./components/ShoppingPage";
-import MusicPage from "./components/MusicPage";
-import FoodDrinkPage from "./components/FoodDrinkPage";
-import TravelPage from "./components/TravelPage";
+import CategoryPage from "./pages/category/CategoryPage";
 import AboutUsPage from "./components/AboutUsPage";
 import ContactPage from "./components/ContactPage";
 import FAQPage from "./components/FAQPage";
@@ -19,12 +14,12 @@ export default function App(){
       <main className="container" style={{padding:"32px 0"}}>
         <Routes>
           <Route path="/" element={<HomePage/>}/>
-          <Route path="/gaming" element={<GamingPage/>}/>
-          <Route path="/streaming" element={<StreamingPage/>}/>
-          <Route path="/shopping" element={<ShoppingPage/>}/>
-          <Route path="/music" element={<MusicPage/>}/>
-          <Route path="/fooddrink" element={<FoodDrinkPage/>}/>
-          <Route path="/travel" element={<TravelPage/>}/>
+          <Route path="/gaming" element={<CategoryPage category="gaming"/>}/>
+          <Route path="/streaming" element={<CategoryPage category="streaming"/>}/>
+          <Route path="/shopping" element={<CategoryPage category="shopping"/>}/>
+          <Route path="/music" element={<CategoryPage category="music"/>}/>
+          <Route path="/fooddrink" element={<CategoryPage category="fooddrink"/>}/>
+          <Route path="/travel" element={<CategoryPage category="travel"/>}/>
           <Route path="/about" element={<AboutUsPage/>}/>
           <Route path="/contact" element={<ContactPage/>}/>
           <Route path="/faq" element={<FAQPage/>}/>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,7 @@
+export const api = {
+  get: async <T>(url: string): Promise<T> => {
+    const res = await fetch("/api" + url);
+    if (!res.ok) throw new Error("API request failed");
+    return res.json();
+  },
+};

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -1,0 +1,31 @@
+import { api } from "./api";
+import type { Product } from "../pages/category/types";
+
+export const Catalog = {
+  list: async (params: { category: string; q?: string; sort?: string; view?: string; regions?: string[]; inStock?: boolean }) => {
+    const query = new URLSearchParams({
+      category: params.category,
+      ...(params.q ? { q: params.q } : {}),
+      ...(params.sort ? { sort: params.sort } : {}),
+      ...(params.inStock ? { inStock: "1" } : {}),
+      ...(params.regions?.length ? { regions: params.regions.join(",") } : {}),
+    }).toString();
+    try {
+      return await api.get<{products: Product[]; total: number}>(`/cards?${query}`);
+    } catch {
+      const products: Product[] = Array.from({ length: 12 }, (_, i) => ({
+        id: `stub-${i+1}`,
+        name: `Sample Product ${i+1}`,
+        img: "/assets/images/placeholder.webp",
+        price: 10 + i,
+        oldPrice: 15 + i,
+        rating: 4.5,
+        discount: 5,
+        platform: i % 3 === 0 ? "XBOX" : i % 3 === 1 ? "PLAYSTATION" : "STEAM",
+        instant: true,
+        region: "US",
+      }));
+      return { products, total: products.length };
+    }
+  },
+};

--- a/frontend/src/pages/category/CategoryBanner.tsx
+++ b/frontend/src/pages/category/CategoryBanner.tsx
@@ -1,0 +1,20 @@
+import type { CategoryKey } from "./types";
+const meta: Record<CategoryKey,{title:string; subtitle:string; color:string; icon?:string}> = {
+  gaming: { title:"Gaming Gift Cards", subtitle:"Get gift cards for Xbox, PlayStation, and Steam gaming platforms", color:"#ff1f62" },
+  streaming: { title:"Streaming Cards", subtitle:"Netflix, Disney+, Spotify & more", color:"#7C3AED" },
+  shopping: { title:"Shopping Cards", subtitle:"Amazon, eBay, Target — easy and fast", color:"#2563EB" },
+  music: { title:"Music Cards", subtitle:"Apple Music, Spotify, YouTube", color:"#10B981" },
+  fooddrink: { title:"Food & Drink Cards", subtitle:"Starbucks, DoorDash, Uber Eats", color:"#F97316" },
+  travel: { title:"Travel Cards", subtitle:"Airbnb, Booking.com, Uber", color:"#06B6D4" },
+};
+export default function CategoryBanner({category}:{category:CategoryKey}){
+  const m = meta[category];
+  return (
+    <div style={{background:m.color, borderRadius:16, color:"#fff", padding:"24px 24px", margin:"16px 0"}}>
+      <div className="container" style={{padding:0}}>
+        <div style={{fontWeight:700, fontSize:22, marginBottom:6}}>{m.title}</div>
+        <div style={{opacity:.9}}>{m.subtitle}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from "react";
+import CategoryBanner from "./CategoryBanner";
+import FiltersSidebar, { Filters } from "./FiltersSidebar";
+import SortBar from "./SortBar";
+import ProductCard from "./ProductCard";
+import { Catalog } from "../../lib/services";
+import type { CategoryKey, Product } from "./types";
+
+export default function CategoryPage({category}:{category:CategoryKey}){
+  const [loading,setLoading] = useState(true);
+  const [items,setItems] = useState<Product[]>([]);
+  const [total,setTotal] = useState(0);
+  const [sort,setSort] = useState("popular");
+  const [view,setView] = useState<"grid"|"list">("grid");
+  const [filters,setFilters] = useState<Filters>({ platform:"All Platforms", regions:{}, inStock:false });
+
+  const regionsSelected = useMemo(()=>Object.keys(filters.regions).filter(r=>filters.regions[r]), [filters]);
+
+  useEffect(()=>{
+    setLoading(true);
+    Catalog.list({
+      category,
+      sort,
+      inStock: filters.inStock,
+      regions: regionsSelected.length ? regionsSelected : undefined,
+    }).then(r=>{ setItems(r.products); setTotal(r.total); })
+      .finally(()=>setLoading(false));
+  },[category,sort,filters.inStock,regionsSelected.join(",")]);
+
+  return (
+    <div className="container">
+      <CategoryBanner category={category}/>
+      <div style={{display:"grid", gridTemplateColumns:"280px 1fr", gap:16}}>
+        <FiltersSidebar value={filters} onChange={setFilters}/>
+        <div style={{display:"grid", gap:12}}>
+          <SortBar total={total} sort={sort} onSort={setSort} view={view} onView={setView}/>
+          {loading ? <div className="muted">Loading…</div> : (
+            <div className={view==="grid" ? "grid featured" : "list"}>
+              {items.map(p => <ProductCard key={p.id} p={p}/>)}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/category/FiltersSidebar.tsx
+++ b/frontend/src/pages/category/FiltersSidebar.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+export type Filters = { platform: string; regions: Record<string,boolean>; inStock: boolean };
+export default function FiltersSidebar({value,onChange}:{value:Filters; onChange:(f:Filters)=>void}){
+  const change = (patch:Partial<Filters>) => onChange({...value, ...patch});
+  const platforms = ["All Platforms","Xbox","PlayStation","Steam"];
+  const regions = useMemo(()=>["US","EU","UA","PL","NL","DE","CA"],[]);
+  return (
+    <aside className="card" style={{padding:16, position:"sticky", top:86}}>
+      <div className="f-title">Gaming Platform</div>
+      <div className="f-stack">
+        {platforms.map(p=>(
+          <button key={p}
+            className={"f-pill" + (value.platform===p ? " active":"")}
+            onClick={()=>change({platform:p})}
+          >{p}</button>
+        ))}
+      </div>
+
+      <div className="f-title" style={{marginTop:18}}>Availability</div>
+      <label className="f-check">
+        <input type="checkbox" checked={value.inStock} onChange={e=>change({inStock:e.target.checked})}/>
+        <span>In Stock Only</span>
+      </label>
+
+      <div className="f-title" style={{marginTop:18}}>Region</div>
+      <div className="f-list">
+        {regions.map(r=>(
+          <label key={r} className="f-check">
+            <input type="checkbox"
+              checked={value.regions[r] ?? false}
+              onChange={e=>change({regions:{...value.regions,[r]:e.target.checked}})}
+            />
+            <span>{r}</span>
+          </label>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/pages/category/ProductCard.tsx
+++ b/frontend/src/pages/category/ProductCard.tsx
@@ -1,0 +1,38 @@
+import type { Product } from "./types";
+import { addToCart, removeFromCart, inCart, qtyOf, setQty } from "../../store/cart";
+
+export default function ProductCard({p}:{p:Product}){
+  const added = inCart(p.id);
+  const qty = qtyOf(p.id);
+  return (
+    <div className="card" style={{padding:12}}>
+      <div style={{position:"relative"}}>
+        {p.discount ? <span className="badge-tag">-{p.discount}%</span> : null}
+        <img src={p.img || "/assets/images/placeholder.webp"} alt={p.name} loading="lazy" style={{width:"100%",height:180,objectFit:"cover",borderRadius:12}}/>
+        {p.platform && <span className="badge-tag top-right">{p.platform}</span>}
+      </div>
+      <div style={{marginTop:10, fontWeight:600}}>{p.name}</div>
+      <div className="muted" style={{display:"flex", gap:8, alignItems:"center", margin:"4px 0"}}>
+        <span>★ {p.rating.toFixed(1)}</span>
+        {p.instant && <span className="chip">Instant</span>}
+      </div>
+      <div style={{display:"flex", gap:8, alignItems:"baseline"}}>
+        <div style={{fontWeight:700}}>${p.price}</div>
+        {p.oldPrice ? <div className="muted" style={{textDecoration:"line-through"}}>${p.oldPrice}</div> : null}
+      </div>
+
+      {!added ? (
+        <button className="btn primary" style={{marginTop:10}} onClick={()=>addToCart({id:p.id,name:p.name,price:p.price,img:p.img})}>Add to Cart</button>
+      ) : (
+        <div style={{marginTop:10, display:"grid", gap:8}}>
+          <div className="qtyrow">
+            <button className="btn sm" onClick={()=>setQty(p.id, Math.max(1, qty-1))}>–</button>
+            <span className="qty">{qty}</span>
+            <button className="btn sm" onClick={()=>setQty(p.id, qty+1)}>+</button>
+          </div>
+          <button className="btn danger" onClick={()=>removeFromCart(p.id)}>Remove from Cart</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/category/SortBar.tsx
+++ b/frontend/src/pages/category/SortBar.tsx
@@ -1,0 +1,20 @@
+export default function SortBar({total, sort, onSort, view, onView}:{total:number; sort:string; onSort:(v:string)=>void; view:"grid"|"list"; onView:(v:"grid"|"list")=>void;}){
+  return (
+    <div className="card" style={{padding:"10px 12px", display:"flex", alignItems:"center", justifyContent:"space-between"}}>
+      <div className="muted">{total} products found</div>
+      <div style={{display:"flex", gap:10, alignItems:"center"}}>
+        <label className="muted">Sort by</label>
+        <select value={sort} onChange={e=>onSort(e.target.value)}>
+          <option value="popular">Popular</option>
+          <option value="priceAsc">Price: Low → High</option>
+          <option value="priceDesc">Price: High → Low</option>
+          <option value="ratingDesc">Rating</option>
+        </select>
+        <div className="view">
+          <button className={"icon-btn"+(view==="grid"?" active":"")} onClick={()=>onView("grid")} aria-label="Grid">▦</button>
+          <button className={"icon-btn"+(view==="list"?" active":"")} onClick={()=>onView("list")} aria-label="List">≣</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/category/types.ts
+++ b/frontend/src/pages/category/types.ts
@@ -1,0 +1,14 @@
+export type Product = {
+  id: string;
+  name: string;
+  img?: string;
+  price: number;
+  oldPrice?: number;
+  rating: number;          // 0..5
+  reviews?: number;
+  platform?: "XBOX"|"PLAYSTATION"|"STEAM"|"US"|"GLOBAL"|"APPLE"|"GOOGLE";
+  instant?: boolean;
+  discount?: number;       // у %
+  region?: string;         // US/EU/UA/...
+};
+export type CategoryKey = "gaming"|"streaming"|"shopping"|"music"|"fooddrink"|"travel";

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -129,3 +129,21 @@ a:hover{ text-decoration:underline }
 .soc{ display:flex; gap:10px; margin-top:8px }
 .f-copy{ color:#9CA3AF; font-size:13px; padding:14px 0; border-top:1px solid #15162b }
 
+/* badges/chips */
+.badge-tag{ position:absolute; left:10px; top:10px; background:#0B0B1C; color:#fff; border-radius:999px; font-size:12px; padding:4px 8px }
+.badge-tag.top-right{ left:auto; right:10px }
+.chip{ background:#EEF2FF; color:#3730A3; border-radius:999px; padding:2px 8px; font-size:12px }
+
+/* filters */
+.f-stack{ display:grid; gap:8px }
+.f-pill{ border:1px solid var(--card-border); background:#fff; border-radius:10px; padding:8px 12px; cursor:pointer; text-align:left }
+.f-pill.active{ background:#0B0B1C; color:#fff; border-color:#0B0B1C }
+.f-check{ display:flex; gap:8px; align-items:center; padding:6px 2px }
+
+/* list view */
+.list .card{ display:flex; gap:12px; align-items:flex-start }
+.list .card img{ width:220px; height:140px }
+
+/* hover animations */
+.card, .cat-card { transition: transform .18s ease, box-shadow .18s ease }
+.card:hover { transform: translateY(-4px); box-shadow: 0 18px 46px rgba(17,24,39,.12) }


### PR DESCRIPTION
## Summary
- build generic category catalog with banner, filters, sorting and product grid
- add Catalog service with temporary stubbed data
- route category URLs to new CategoryPage and style badges/filters

## Testing
- `npm test` (missing script)
- `npm run build` (failed: vite not found)
- `npm install` (failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68aee95ad194832b8ce495c429eb865d