### PR TITLE
feat: add sticky header with scroll shadow

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,26 +1,44 @@
-export default function Header() {
+import { Link, NavLink } from "react-router-dom";
+import CartIcon from "./icons/CartIcon";
+import { LanguageMenu, CurrencyMenu } from "./menus/LanguageCurrencyMenu";
+import { useEffect, useState } from "react";
+import { totalCount } from "../store/cart";
+
+export default function Header(){
+  const [lang,setLang] = useState("EN");
+  const [cur,setCur] = useState("USD");
+  const [count,setCount] = useState(0);
+  useEffect(()=>{
+    setCount(totalCount());
+    const t=setInterval(()=>setCount(totalCount()),800);
+    return ()=>clearInterval(t);
+  },[]);
+
   return (
-    <header className="site-header">
-      <div className="container header-inner">
-        <div className="logo">DigiGames</div>
-        {/* пошук */}
-        <input type="search" className="search" placeholder="Search gift cards..." />
-        {/* кнопки мова/валюта/корзина */}
-        <div className="header-actions">
-          <button className="icon-btn">🌐</button>
-          <button className="icon-btn">$</button>
-          <button className="icon-btn">🛒</button>
+    <header className="header-wrap"> {/* <-- sticky застосуємо до цього контейнера */}
+      <div className="topbar">
+        <div className="container topbar-inner">
+          <Link to="/" className="brand">DigiGames</Link>
+          <div className="search"><input placeholder="Search gift cards..." /></div>
+          <nav className="topnav" aria-label="Actions">
+            <LanguageMenu value={lang} onChange={setLang}/>
+            <CurrencyMenu value={cur} onChange={setCur}/>
+            <Link to="/cart" className="icon-btn badge" aria-label="Cart">
+              <CartIcon/>{count>0 && <span className="badge-dot">{count}</span>}
+            </Link>
+          </nav>
         </div>
       </div>
-      {/* навігація */}
-      <nav className="nav">
-        <a href="/gaming">Gaming</a>
-        <a href="/streaming">Streaming</a>
-        <a href="/shopping">Shopping</a>
-        <a href="/music">Music</a>
-        <a href="/fooddrink">Food & Drink</a>
-        <a href="/travel">Travel</a>
-      </nav>
+
+      <div className="topcats container">
+        <NavLink to="/" end>Home</NavLink>
+        <NavLink to="/gaming">Gaming</NavLink>
+        <NavLink to="/streaming">Streaming</NavLink>
+        <NavLink to="/shopping">Shopping</NavLink>
+        <NavLink to="/music">Music</NavLink>
+        <NavLink to="/fooddrink">Food & Drink</NavLink>
+        <NavLink to="/travel">Travel</NavLink>
+      </div>
     </header>
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,4 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./styles/global.css";
 import App from "./App";
+
+if (typeof window !== "undefined") {
+  const onScroll = () => {
+    if (window.scrollY > 2) document.body.classList.add("has-scroll");
+    else document.body.classList.remove("has-scroll");
+  };
+  window.addEventListener("scroll", onScroll, { passive: true });
+  onScroll();
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2,13 +2,13 @@
 
 *,*::before,*::after{box-sizing:border-box}
 html,body,#root{height:100%}
-/* щоб контент не заїжджав під хедер */
+/* 0) скасувати попереднє */
 body{
   margin:0;background:#F7F7FB;color:#111827;
   font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
   -webkit-font-smoothing:antialiased;
   -moz-osx-font-smoothing:grayscale;
-  padding-top:96px; /* висота хедера (можна підправити) */
+  padding-top:0 !important;
 }
 :root{
   --brand:#6F42C1; --ink:#111827; --muted:#6B7280;
@@ -19,12 +19,17 @@ body{
 .container{max-width:var(--container);margin:0 auto;padding:0 24px}
 .section-title{font-size:28px;font-weight:700;letter-spacing:-.01em;margin:32px 0 16px}
 
-.topbar{background:#fff;border-bottom:1px solid var(--card-border)}
-.topbar-inner{height:64px;display:flex;align-items:center;gap:16px}
+.header-wrap{
+  position:sticky;top:0;z-index:50;
+  background:#fff;
+  border-bottom:1px solid var(--card-border);
+  box-shadow:0 0 0 rgba(0,0,0,0);
+  transition:box-shadow .15s ease;
+}
+.topbar{ background:#fff; }
+.topbar-inner{height:64px;display:flex;align-items:center;gap:16px;padding:0}
 .brand{font-weight:700;font-size:22px;color:var(--ink);text-decoration:none}
-.topnav{display:flex;gap:16px;font-size:14px}
-.topnav a{color:#374151;text-decoration:none;padding:8px 10px;border-radius:8px}
-.topnav a:hover{background:#F3F4F6}
+.topnav{display:flex;gap:12px;align-items:center}
 .search{flex:1;display:flex;justify-content:center}
 .search input{
   width:min(560px,100%);
@@ -34,12 +39,13 @@ body{
   outline:none;
   background:#fff;
 }
-
 .icon-btn{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border:1px solid var(--card-border);border-radius:10px;background:#fff;color:#374151;cursor:pointer}
 .icon-btn:hover{background:#F3F4F6}
+.topcats{ display:flex; gap:12px; align-items:center; height:44px; }
+.topcats a{ color:#4b5563; text-decoration:none; padding:8px 10px; border-radius:8px }
+.topcats a:hover{ background:#F3F4F6 }
+.has-scroll .header-wrap{ box-shadow: 0 2px 10px rgba(17,24,39,.08); }
 
-.btn{border:1px solid var(--card-border);background:#fff;border-radius:10px;padding:8px 12px;font-weight:600;cursor:pointer}
-.btn:hover{background:#F3F4F6}
 
 .grid{display:grid;gap:16px}
 .grid.categories{grid-template-columns:repeat(1,1fr)}
@@ -96,10 +102,6 @@ a:hover{ text-decoration:underline }
   min-width:18px; height:18px; display:grid; place-items:center; border-radius:999px; padding:0 4px;
 }
 
-/* second row of header categories */
-.topcats{ display:flex; gap:12px; align-items:center; height:44px; }
-.topcats a{ color:#4b5563; text-decoration:none; padding:8px 10px; border-radius:8px }
-.topcats a:hover{ background:#F3F4F6 }
 
 /* buttons */
 .btn{ border:1px solid var(--card-border); background:#fff; border-radius:10px; padding:8px 12px; font-weight:600; cursor:pointer }
@@ -150,36 +152,3 @@ a:hover{ text-decoration:underline }
 .card, .cat-card { transition: transform .18s ease, box-shadow .18s ease }
 .card:hover { transform: translateY(-4px); box-shadow: 0 18px 46px rgba(17,24,39,.12) }
 
-/* Sticky Header */
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: #fff;
-  border-bottom: 1px solid #e5e7eb;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.04);
-}
-
-/* внутрішня частина */
-.header-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 12px 0;
-}
-
-.nav {
-  display: flex;
-  gap: 16px;
-  padding: 8px 0;
-}
-
-.nav a {
-  font-weight: 500;
-  color: #111;
-  text-decoration: none;
-}
-.nav a:hover {
-  color: #2563eb;
-}


### PR DESCRIPTION
## Summary
- make site header sticky and split into top and category rows
- streamline global styles and remove body padding
- add scroll listener for header shadow effect

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run build` (frontend) *(fails: vite: not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aefa16d3b8832b89e9412575bb1478