### PR TITLE
feat: implement checkout cart page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import CategoryPage from "./pages/category/CategoryPage";
 import AboutUsPage from "./components/AboutUsPage";
 import ContactPage from "./components/ContactPage";
 import FAQPage from "./components/FAQPage";
-import CartPage from "./components/CartPage";
+import CartPage from "./pages/checkout/CartPage";
 export default function App(){
   return (
     <BrowserRouter>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,13 +6,14 @@ import { totalCount } from "../store/cart";
 
 export default function Header(){
   const [lang,setLang] = useState("EN");
-  const [cur,setCur] = useState("USD");
+  const [cur,setCur] = useState(localStorage.getItem("dg_currency") || "USD");
   const [count,setCount] = useState(0);
   useEffect(()=>{
     setCount(totalCount());
     const t=setInterval(()=>setCount(totalCount()),800);
     return ()=>clearInterval(t);
   },[]);
+  useEffect(()=>{ localStorage.setItem("dg_currency", cur); }, [cur]);
 
   return (
     <header className="header-wrap"> {/* <-- sticky застосуємо до цього контейнера */}

--- a/frontend/src/pages/checkout/CartPage.tsx
+++ b/frontend/src/pages/checkout/CartPage.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from "react";
+import { getCart, setQty, removeFromCart, subtotal, totalCount } from "../../store/cart";
+import { money, safeMul } from "./cartUtils";
+
+type Summary = { itemsTotal:number; discount:number; subTotal:number; total:number };
+
+const getCurrency = () => localStorage.getItem("dg_currency") || "USD";
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function CartPage(){
+  const [items, setItems] = useState(getCart());
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [currency, setCurrency] = useState(getCurrency());
+
+  useEffect(()=>{
+    const t = setInterval(()=> setItems(getCart()), 600);
+    return ()=> clearInterval(t);
+  },[]);
+
+  const summary: Summary = useMemo(()=>{
+    const sub = subtotal();
+    const discount = code.trim().toUpperCase()==="SAVE5" ? Math.min(sub*0.05, 50) : 0;
+    const total = Math.max(0, sub - discount);
+    return { itemsTotal: totalCount(), discount, subTotal: sub, total };
+  }, [items, code]);
+
+  const canPay = items.length>0 && emailRe.test(email);
+
+  return (
+    <div className="container checkout">
+      <div className="co-left">
+        <div className="card">
+          <div className="co-title">Shopping Cart</div>
+          <div className="co-badge">✅ Instant e-mail delivery</div>
+
+          {items.length===0 && <div className="muted" style={{padding:"12px 0"}}>Your cart is empty.</div>}
+
+          {items.map(it=>(
+            <div className="co-item" key={it.id}>
+              <img src={it.img || "/assets/images/placeholder.webp"} alt="" />
+              <div className="co-item-meta">
+                <div className="co-name">{it.name}</div>
+                <div className="co-submeta">
+                  <span>{it.region || "US"}</span>
+                  {it.instant && <span className="chip">Instant delivery</span>}
+                </div>
+                <div className="co-qty">
+                  <button className="btn sm" onClick={()=>{ setQty(it.id, it.qty-1); setItems(getCart()); }}>–</button>
+                  <span className="qty">{it.qty}</span>
+                  <button className="btn sm" onClick={()=>{ setQty(it.id, it.qty+1); setItems(getCart()); }}>+</button>
+                  <button className="icon-x" aria-label="Remove" onClick={()=>{ removeFromCart(it.id); setItems(getCart()); }}>×</button>
+                </div>
+              </div>
+              <div className="co-price">
+                {money(safeMul(it.price, it.qty), currency)}
+              </div>
+            </div>
+          ))}
+
+          {items.length>0 && (
+            <div className="co-continue">
+              Not ready to checkout? <a href="/">Continue Shopping</a>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <aside className="co-right">
+        <div className="card">
+          <div className="co-right-title">Instant delivery to <span className="req">(Required)</span></div>
+          <label className="field">
+            <input
+              type="email"
+              placeholder="your@email.com"
+              value={email}
+              onChange={e=>setEmail(e.target.value)}
+            />
+          </label>
+          <div className="muted">Unlock exclusive deals and insider tips</div>
+
+          <div className="divider"/>
+
+          <div className="co-right-title">Order Summary</div>
+          <div className="muted">Items in your cart (incl. service costs)</div>
+          <div className="co-row">
+            <span>{summary.itemsTotal}× items</span>
+            <span>{money(summary.subTotal, currency)}</span>
+          </div>
+
+          <details className="discount">
+            <summary>Discount Code</summary>
+            <div className="discount-inner">
+              <input placeholder="Enter code (e.g. SAVE5)" value={code} onChange={e=>setCode(e.target.value)} />
+              {!!summary.discount && <div className="applied">− {money(summary.discount, currency)} applied</div>}
+            </div>
+          </details>
+
+          <div className="divider"/>
+          <div className="co-row total">
+            <span>Total</span>
+            <span>{money(summary.total, currency)}</span>
+          </div>
+
+          <button className="btn primary co-cta" disabled={!canPay}>
+            Choose Payment Method
+          </button>
+          {!canPay && <div className="muted" style={{fontSize:12}}>Enter a valid email to continue</div>}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/pages/checkout/cartUtils.ts
+++ b/frontend/src/pages/checkout/cartUtils.ts
@@ -1,0 +1,8 @@
+export const money = (value:number, currency:string="USD") =>
+  new Intl.NumberFormat("en-US", { style:"currency", currency, maximumFractionDigits:2 }).format(Number.isFinite(value)?value:0);
+
+export const safeMul = (a:any, b:any) => {
+  const x = Number.isFinite(+a)?+a:0;
+  const y = Number.isFinite(+b)?+b:0;
+  return x*y;
+};

--- a/frontend/src/store/cart.ts
+++ b/frontend/src/store/cart.ts
@@ -1,29 +1,39 @@
-export type Item = { id: string; name: string; price: number; img?: string; qty: number };
-const KEY = "dg_cart_v1";
+export type Item = { id:string; name:string; price:number; img?:string; qty:number; region?:string; instant?:boolean };
+
+const KEY="dg_cart_v1";
+const safeN = (n:any, def=0)=> Number.isFinite(+n) ? +n : def;
 
 export const getCart = (): Item[] => {
-  try { return JSON.parse(localStorage.getItem(KEY) || "[]"); } catch { return []; }
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) || "[]");
+    return Array.isArray(raw) ? raw.map((i:any)=>({
+      id: String(i.id),
+      name: String(i.name ?? ""),
+      price: safeN(i.price, 0),
+      img: i.img || undefined,
+      qty: Math.max(1, safeN(i.qty, 1)),
+      region: i.region || "US",
+      instant: Boolean(i.instant ?? true),
+    })) : [];
+  } catch { return []; }
 };
-export const setCart = (items: Item[]) => localStorage.setItem(KEY, JSON.stringify(items));
+export const setCart = (v: Item[]) => localStorage.setItem(KEY, JSON.stringify(v));
 
-export const addToCart = (item: Omit<Item,"qty"> & { qty?: number }) => {
+export const addToCart = (item: Omit<Item,"qty"> & { qty?:number }) => {
   const cart = getCart();
   const idx = cart.findIndex(i => i.id === item.id);
-  if (idx === -1) cart.push({ ...item, qty: item.qty ?? 1 });
-  else cart[idx].qty += item.qty ?? 1;
+  if (idx === -1) cart.push({ ...item, qty: Math.max(1, safeN(item.qty,1)) });
+  else cart[idx].qty += Math.max(1, safeN(item.qty,1));
   setCart(cart);
 };
-export const removeFromCart = (id: string) => {
-  const cart = getCart().filter(i => i.id !== id);
-  setCart(cart);
-};
-export const setQty = (id: string, qty: number) => {
+export const setQty = (id:string, qty:number) => {
   const cart = getCart();
-  const it = cart.find(i => i.id === id);
-  if (!it) return;
-  it.qty = Math.max(1, qty);
+  const it = cart.find(i=>i.id===id); if (!it) return;
+  it.qty = Math.max(1, safeN(qty,1));
   setCart(cart);
 };
-export const inCart = (id: string) => getCart().some(i => i.id === id);
-export const qtyOf = (id: string) => getCart().find(i => i.id === id)?.qty ?? 0;
-export const totalCount = () => getCart().reduce((s,i)=>s+i.qty,0);
+export const removeFromCart = (id:string) => setCart(getCart().filter(i=>i.id!==id));
+export const inCart = (id:string) => getCart().some(i=>i.id===id);
+export const qtyOf = (id:string) => getCart().find(i=>i.id===id)?.qty ?? 0;
+export const totalCount = () => getCart().reduce((s,i)=> s + Math.max(1, safeN(i.qty,1)), 0);
+export const subtotal = () => getCart().reduce((s,i)=> s + safeN(i.price,0) * Math.max(1,safeN(i.qty,1)), 0);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -152,3 +152,44 @@ a:hover{ text-decoration:underline }
 .card, .cat-card { transition: transform .18s ease, box-shadow .18s ease }
 .card:hover { transform: translateY(-4px); box-shadow: 0 18px 46px rgba(17,24,39,.12) }
 
+/* ===== Checkout ===== */
+.checkout{ display:grid; gap:16px; grid-template-columns: 1fr; }
+@media(min-width: 960px){ .checkout{ grid-template-columns: minmax(0,1fr) 360px; } }
+
+.co-left .card, .co-right .card{ padding:16px; }
+.co-title{ font-weight:700; font-size:18px; margin-bottom:6px; }
+.co-badge{ color:#059669; font-size:13px; margin-bottom:10px; }
+
+.co-item{ display:grid; grid-template-columns: 72px 1fr auto; gap:12px; align-items:center; padding:10px 0; border-top:1px solid var(--card-border); }
+.co-item:first-of-type{ border-top:0; }
+.co-item img{ width:72px; height:48px; object-fit:cover; border-radius:10px; background:#e5e7eb; }
+.co-item .co-name{ font-weight:600; margin-bottom:4px; }
+.co-submeta{ display:flex; gap:10px; align-items:center; color:var(--muted); font-size:13px; }
+.co-submeta .chip{ background:#EEF2FF; color:#3730A3; border-radius:999px; padding:2px 8px; font-size:12px; }
+.co-qty{ display:flex; align-items:center; gap:8px; margin-top:8px; }
+.icon-x{ width:32px; height:32px; border-radius:8px; border:1px solid var(--card-border); background:#fff; cursor:pointer; line-height:0; font-size:18px; }
+.icon-x:hover{ background:#F3F4F6; }
+.co-price{ font-weight:700; }
+
+.co-continue{ margin-top:10px; font-size:14px; }
+.co-continue a{ color:var(--brand); text-decoration:none } .co-continue a:hover{text-decoration:underline}
+
+.co-right-title{ font-weight:600; margin-bottom:8px; }
+.req{ color:#DC2626; }
+.field input{
+  width:100%; border:1px solid var(--card-border); border-radius:12px; padding:10px 12px; outline:none; background:#fff;
+}
+.divider{ height:1px; background:var(--card-border); margin:14px 0; }
+.co-row{ display:flex; align-items:center; justify-content:space-between; padding:6px 0; }
+.co-row.total{ font-weight:700; font-size:18px; }
+
+.discount summary{ cursor:pointer; padding:4px 0; color:var(--brand); }
+.discount-inner{ display:grid; gap:6px; padding:8px 0; }
+.discount-inner input{
+  width:100%; border:1px dashed var(--card-border); border-radius:10px; padding:8px 10px; background:#fff;
+}
+.discount .applied{ color:#059669; font-size:13px; }
+
+.co-cta{ width:100%; margin-top:12px; padding:12px; }
+.btn[disabled]{ opacity:.5; cursor:not-allowed; }
+


### PR DESCRIPTION
## Summary
- add checkout cart page with order summary and discount code
- safeguard cart store with numeric fallbacks and subtotal helper
- style checkout layout and persist currency in header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build` (frontend) *(fails: vite: not found)*
- `npm install` (frontend) *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b003928dc8832b9f95f59ae925601c