### PR TITLE
feat: add payment method selection page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import AboutUsPage from "./components/AboutUsPage";
 import ContactPage from "./components/ContactPage";
 import FAQPage from "./components/FAQPage";
 import CartPage from "./pages/checkout/CartPage";
+import PaymentPage from "./pages/checkout/PaymentPage";
 export default function App(){
   return (
     <BrowserRouter>
@@ -24,6 +25,7 @@ export default function App(){
           <Route path="/contact" element={<ContactPage/>}/>
           <Route path="/faq" element={<FAQPage/>}/>
           <Route path="/cart" element={<CartPage/>}/>
+          <Route path="/checkout/payment" element={<PaymentPage/>}/>
         </Routes>
       </main>
       <Footer/>

--- a/frontend/src/pages/checkout/CartPage.tsx
+++ b/frontend/src/pages/checkout/CartPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { getCart, setQty, removeFromCart, subtotal, totalCount } from "../../store/cart";
 import { money, safeMul } from "./cartUtils";
 
@@ -9,9 +10,10 @@ const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function CartPage(){
   const [items, setItems] = useState(getCart());
-  const [email, setEmail] = useState("");
-  const [code, setCode] = useState("");
+  const [email, setEmail] = useState(localStorage.getItem("dg_checkout_email") || "");
+  const [code, setCode] = useState(localStorage.getItem("dg_coupon") || "");
   const [currency, setCurrency] = useState(getCurrency());
+  const navigate = useNavigate();
 
   useEffect(()=>{
     const t = setInterval(()=> setItems(getCart()), 600);
@@ -74,7 +76,7 @@ export default function CartPage(){
               type="email"
               placeholder="your@email.com"
               value={email}
-              onChange={e=>setEmail(e.target.value)}
+              onChange={e=>{ setEmail(e.target.value); localStorage.setItem("dg_checkout_email", e.target.value); }}
             />
           </label>
           <div className="muted">Unlock exclusive deals and insider tips</div>
@@ -91,7 +93,7 @@ export default function CartPage(){
           <details className="discount">
             <summary>Discount Code</summary>
             <div className="discount-inner">
-              <input placeholder="Enter code (e.g. SAVE5)" value={code} onChange={e=>setCode(e.target.value)} />
+              <input placeholder="Enter code (e.g. SAVE5)" value={code} onChange={e=>{ setCode(e.target.value); localStorage.setItem("dg_coupon", e.target.value); }} />
               {!!summary.discount && <div className="applied">− {money(summary.discount, currency)} applied</div>}
             </div>
           </details>
@@ -102,7 +104,7 @@ export default function CartPage(){
             <span>{money(summary.total, currency)}</span>
           </div>
 
-          <button className="btn primary co-cta" disabled={!canPay}>
+          <button className="btn primary co-cta" disabled={!canPay} onClick={()=>{ localStorage.setItem("dg_checkout_email", email); navigate("/checkout/payment"); }}>
             Choose Payment Method
           </button>
           {!canPay && <div className="muted" style={{fontSize:12}}>Enter a valid email to continue</div>}

--- a/frontend/src/pages/checkout/PaymentPage.tsx
+++ b/frontend/src/pages/checkout/PaymentPage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react";
+import { getCart, subtotal, totalCount } from "../../store/cart";
+import { METHOD_FEE, METHOD_LABEL, PayMethod } from "./fees";
+
+const safeN = (n:any, d=0)=> Number.isFinite(+n) ? +n : d;
+const money = (v:number, cur="USD") =>
+  new Intl.NumberFormat("en-US",{style:"currency",currency:cur,maximumFractionDigits:2})
+    .format(Number.isFinite(v)?v:0);
+
+const getCurrency = () => localStorage.getItem("dg_currency") || "USD";
+const getEmail    = () => localStorage.getItem("dg_checkout_email") || "";   // збережи email на CartPage перед переходом
+
+export default function PaymentPage(){
+  const [items, setItems] = useState(getCart());
+  const [email, setEmail] = useState(getEmail());
+  const [currency] = useState(getCurrency());
+  const [method, setMethod] = useState<PayMethod>("paypal");
+  const [agree, setAgree]   = useState(false);
+  const [code, setCode]     = useState(localStorage.getItem("dg_coupon") || "");
+
+  // автооновлення кошика
+  useEffect(()=>{
+    const t=setInterval(()=> setItems(getCart()), 800);
+    return ()=> clearInterval(t);
+  },[]);
+
+  const sums = useMemo(()=>{
+    const sub = subtotal();
+    const discount = code.trim().toUpperCase()==="SAVE5" ? Math.min(sub*0.05, 50) : 0;
+    const feePct = safeN(METHOD_FEE[method], 0);
+    const txn = Math.max(0, (sub - discount) * (feePct/100));
+    const total = Math.max(0, sub - discount + txn);
+    return { sub, discount, txn, total };
+  }, [items, code, method]);
+
+  const methodLabel = METHOD_LABEL[method];
+  const canProceed = !!email && /\S+@\S+\.\S+/.test(email) && items.length>0 && agree;
+
+  return (
+    <div className="container checkout">
+      {/* LEFT */}
+      <div className="co-left">
+        <div className="card">
+          <div className="co-title">Choose a Payment Method</div>
+          <div className="co-badge">✅ Instant e-mail delivery</div>
+
+          <div className="pm-list">
+            {["paypal","klarna","sofort","daopay","applepay","card"] as PayMethod[].map(m=>(
+              <button key={m}
+                onClick={()=>setMethod(m)}
+                className={"pm-item" + (method===m?" active":"")}
+                aria-pressed={method===m}
+              >
+                <span className="radio">{method===m ? "●" : "○"}</span>
+                <span className="pm-title">{METHOD_LABEL[m]}</span>
+                <span className="pm-fee">+ {safeN(METHOD_FEE[m],0)}%</span>
+              </button>
+            ))}
+          </div>
+
+          {method==="paypal" && (
+            <div className="alert warn">
+              Your code(s) will be sent to the email address linked to your PayPal account, not the one you provided earlier.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* RIGHT */}
+      <aside className="co-right">
+        <div className="card">
+          <div className="co-right-title">Instant delivery to</div>
+          <label className="field">
+            <input type="email" value={email}
+              onChange={e=>{ setEmail(e.target.value); localStorage.setItem("dg_checkout_email", e.target.value); }}
+              placeholder="your@email.com" />
+          </label>
+          <div className="muted">Unlock exclusive deals and insider tips</div>
+
+          <div className="divider"/>
+
+          <div className="co-right-title">Order Summary</div>
+          <div className="muted">Items in your cart (incl. service costs)</div>
+
+          <div className="co-row">
+            <span>{totalCount()}× items</span>
+            <span>{money(sums.sub, currency)}</span>
+          </div>
+
+          <details className="discount" open={!!code}>
+            <summary>Discount Code</summary>
+            <div className="discount-inner">
+              <input placeholder="Enter code (e.g. SAVE5)"
+                     value={code}
+                     onChange={e=>{ setCode(e.target.value); localStorage.setItem("dg_coupon", e.target.value); }}/>
+              {!!sums.discount && <div className="applied">− {money(sums.discount, currency)} applied</div>}
+            </div>
+          </details>
+
+          <div className="co-row">
+            <span>Subtotal</span>
+            <span>{money(Math.max(0, sums.sub - sums.discount), currency)}</span>
+          </div>
+          <div className="co-row">
+            <span>Transaction Costs</span>
+            <span>{money(sums.txn, currency)}</span>
+          </div>
+
+          <div className="divider"/>
+          <div className="co-row total">
+            <span>Total</span>
+            <span>{money(sums.total, currency)}</span>
+          </div>
+
+          <label className="agree">
+            <input type="checkbox" checked={agree} onChange={e=>setAgree(e.target.checked)}/>
+            <span>I agree to <a href="/terms" target="_blank">Terms</a>, <a href="/privacy" target="_blank">Privacy</a> and <a href="/refunds" target="_blank">Return Policy</a></span>
+          </label>
+
+          <button className="btn primary co-cta" disabled={!canProceed}>
+            Continue with {methodLabel}
+          </button>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/pages/checkout/fees.ts
+++ b/frontend/src/pages/checkout/fees.ts
@@ -1,0 +1,21 @@
+export type PayMethod =
+  | "paypal" | "klarna" | "sofort" | "daopay" | "applepay" | "card";
+
+export const METHOD_LABEL: Record<PayMethod,string> = {
+  paypal:   "PayPal",
+  klarna:   "Pay by Bank (Klarna)",
+  sofort:   "Sofort-banking",
+  daopay:   "Phone Payment (Daopay Call)",
+  applepay: "Apple Pay",
+  card:     "VISA / Mastercard / AMEX",
+};
+
+// fee у відсотках (0…100)
+export const METHOD_FEE: Record<PayMethod, number> = {
+  paypal:   2.0,
+  klarna:   2.5,
+  sofort:   2.9,
+  daopay:   0.0,
+  applepay: 5.0,
+  card:     2.9,
+};

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -193,3 +193,24 @@ a:hover{ text-decoration:underline }
 .co-cta{ width:100%; margin-top:12px; padding:12px; }
 .btn[disabled]{ opacity:.5; cursor:not-allowed; }
 
+/* ===== Payment page ===== */
+.pm-list{ display:grid; gap:10px; }
+.pm-item{
+  display:flex; align-items:center; gap:12px;
+  width:100%; background:#fff; border:1px solid var(--card-border); border-radius:12px;
+  padding:12px; cursor:pointer; text-align:left;
+}
+.pm-item:hover{ background:#F8FAFC }
+.pm-item.active{ outline:2px solid #0B0B1C; outline-offset:0; }
+.pm-title{ flex:1; font-weight:600 }
+.pm-fee{ color:#6b7280 }
+.radio{ width:22px; text-align:center }
+
+.alert.warn{
+  margin-top:12px; border:1px solid #FCD34D; background:#FFFBEB; color:#7C2D12;
+  border-radius:12px; padding:10px 12px; font-size:14px;
+}
+
+/* правий блок — повторюємо checkout */
+.agree{ display:flex; gap:8px; align-items:flex-start; margin:10px 0; font-size:14px }
+.agree a{ color:var(--brand); text-decoration:none } .agree a:hover{ text-decoration:underline }


### PR DESCRIPTION
## Summary
- add payment options with fee calculation and summary page
- persist checkout email and coupon and navigate to payment step
- style payment screen and register its route

## Testing
- `npm --prefix frontend ci` *(fails: 403 Forbidden accessing registry)*
- `npm --prefix frontend test` *(fails: Missing script "test")*
- `npm --prefix frontend run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b00ce59f2c832baa52f3740b3e258e