### PR TITLE
feat: add universal frontend API client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 PORT=10000
 DB_URL=mongodb+srv://digi_user:Z3fdj1nFJj4o9DSX@digi.fwbova3.mongodb.net/digibackend?retryWrites=true&w=majority&appName=Digi
 API_KEY=your_api_key_here
+VITE_API_BASE=https://digi-backend-ln8f.onrender.com/api

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,62 @@
+const BASE =
+  (import.meta as any)?.env?.VITE_API_BASE?.replace(/\/+$/, "") ||
+  "/api";
+
+type JSONValue = string | number | boolean | null | JSONValue[] | { [k: string]: JSONValue };
+
+export class ApiError extends Error {
+  status: number;
+  body?: any;
+  constructor(message: string, status: number, body?: any) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export async function fetchJSON<T>(
+  path: string,
+  opts: RequestInit = {},
+  timeoutMs = 15000
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const headers = new Headers(opts.headers || {});
+  if (!headers.has("Content-Type") && opts.body) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (!headers.has("Accept")) headers.set("Accept", "application/json");
+
+  const url = `${BASE}${path.startsWith("/") ? "" : "/"}${path}`;
+
+  try {
+    const res = await fetch(url, { ...opts, headers, signal: controller.signal });
+    const text = await res.text(); // спершу як текст
+    let data: any;
+    try {
+      data = text ? JSON.parse(text) : undefined;
+    } catch {
+      data = text;
+    }
+
+    if (!res.ok) {
+      throw new ApiError(
+        data?.message || data?.error || res.statusText || "Request failed",
+        res.status,
+        data
+      );
+    }
+    return data as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Зручні шорткати */
 export const api = {
-  get: async <T>(url: string): Promise<T> => {
-    const res = await fetch("/api" + url);
-    if (!res.ok) throw new Error("API request failed");
-    return res.json();
-  },
+  get: <T>(p: string) => fetchJSON<T>(p),
+  post: <T>(p: string, body?: JSONValue) =>
+    fetchJSON<T>(p, { method: "POST", body: body ? JSON.stringify(body) : undefined }),
 };
+

--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,9 @@ services:
     name: digi-backend
     env: node
     plan: free
+    envVars:
+      - key: VITE_API_BASE
+        value: https://digi-backend-ln8f.onrender.com/api
     buildCommand: >
       npm --prefix frontend install --no-audit --no-fund --registry=https://registry.npmjs.org
       && npm --prefix frontend run build


### PR DESCRIPTION
## Summary
- add flexible fetchJSON utility with timeout, JSON handling, and custom ApiError
- wire up VITE_API_BASE configuration for frontend build and runtime

## Testing
- `npm --prefix frontend install --no-audit --no-fund` (fails: 403 Forbidden to registry)
- `npm --prefix frontend run build` (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_68b019af4d58832b8b9e11bf6972faa6