### PR TITLE
Use backend API for catalog data

### DIFF
--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -1,31 +1,15 @@
 import { api } from "./api";
-import type { Product } from "../pages/category/types";
+import type { ProductsResponse } from "./types";
 
 export const Catalog = {
-  list: async (params: { category: string; q?: string; sort?: string; view?: string; regions?: string[]; inStock?: boolean }) => {
-    const query = new URLSearchParams({
-      category: params.category,
-      ...(params.q ? { q: params.q } : {}),
-      ...(params.sort ? { sort: params.sort } : {}),
-      ...(params.inStock ? { inStock: "1" } : {}),
-      ...(params.regions?.length ? { regions: params.regions.join(",") } : {}),
-    }).toString();
-    try {
-      return await api.get<{products: Product[]; total: number}>(`/cards?${query}`);
-    } catch {
-      const products: Product[] = Array.from({ length: 12 }, (_, i) => ({
-        id: `stub-${i+1}`,
-        name: `Sample Product ${i+1}`,
-        img: "/assets/images/placeholder.webp",
-        price: 10 + i,
-        oldPrice: 15 + i,
-        rating: 4.5,
-        discount: 5,
-        platform: i % 3 === 0 ? "XBOX" : i % 3 === 1 ? "PLAYSTATION" : "STEAM",
-        instant: true,
-        region: "US",
-      }));
-      return { products, total: products.length };
-    }
+  list: async (params: { category?: string; q?: string; sort?: string; regions?: string[]; inStock?: boolean }) => {
+    const query = new URLSearchParams();
+    if (params.category) query.set("category", params.category);
+    if (params.q) query.set("q", params.q);
+    if (params.sort) query.set("sort", params.sort);
+    if (params.regions?.length) query.set("regions", params.regions.join(","));
+    if (typeof params.inStock === "boolean") query.set("inStock", String(params.inStock));
+    const qs = query.toString();
+    return api.get<ProductsResponse>(`/cards${qs ? `?${qs}` : ""}`);
   },
 };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,18 @@
+export type Product = {
+  id: string;
+  name: string;
+  img?: string;
+  price: number;
+  oldPrice?: number;
+  rating?: number;
+  reviews?: number;
+  platform?: string;   // e.g. STEAM/PLAYSTATION
+  instant?: boolean;
+  discount?: number;   // %
+  region?: string;     // e.g. US
+};
+
+export type ProductsResponse = {
+  products: Product[];
+  total: number;
+};

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -3,11 +3,30 @@ import CategoryBanner from "./CategoryBanner";
 import FiltersSidebar, { Filters } from "./FiltersSidebar";
 import SortBar from "./SortBar";
 import ProductCard from "./ProductCard";
-import { Catalog } from "../../lib/services";
-import type { CategoryKey, Product } from "./types";
+import { api } from "../../lib/api";
+import type { Product, ProductsResponse } from "../../lib/types";
+import type { CategoryKey } from "./types";
+
+const buildQuery = (opts: {
+  category: string;
+  q?: string;
+  sort?: string;
+  regions?: string[];
+  inStock?: boolean;
+}) => {
+  const p = new URLSearchParams();
+  if (opts.category) p.set("category", opts.category);
+  if (opts.q) p.set("q", opts.q);
+  if (opts.sort) p.set("sort", opts.sort);
+  if (opts.regions?.length) p.set("regions", opts.regions.join(","));
+  if (typeof opts.inStock === "boolean") p.set("inStock", String(opts.inStock));
+  const s = p.toString();
+  return s ? `?${s}` : "";
+};
 
 export default function CategoryPage({category}:{category:CategoryKey}){
-  const [loading,setLoading] = useState(true);
+  const [loading,setLoading] = useState(false);
+  const [err,setErr] = useState<string | null>(null);
   const [items,setItems] = useState<Product[]>([]);
   const [total,setTotal] = useState(0);
   const [sort,setSort] = useState("popular");
@@ -16,16 +35,32 @@ export default function CategoryPage({category}:{category:CategoryKey}){
 
   const regionsSelected = useMemo(()=>Object.keys(filters.regions).filter(r=>filters.regions[r]), [filters]);
 
+  const query = useMemo(() => buildQuery({
+    category,
+    sort,
+    regions: regionsSelected.length ? regionsSelected : undefined,
+    inStock: filters.inStock,
+  }), [category, sort, regionsSelected.join(","), filters.inStock]);
+
   useEffect(()=>{
+    let alive = true;
     setLoading(true);
-    Catalog.list({
-      category,
-      sort,
-      inStock: filters.inStock,
-      regions: regionsSelected.length ? regionsSelected : undefined,
-    }).then(r=>{ setItems(r.products); setTotal(r.total); })
-      .finally(()=>setLoading(false));
-  },[category,sort,filters.inStock,regionsSelected.join(",")]);
+    setErr(null);
+    api.get<ProductsResponse>(`/cards${query}`)
+      .then(data => {
+        if (!alive) return;
+        setItems(data?.products ?? []);
+        setTotal(data?.total ?? 0);
+      })
+      .catch(e => {
+        if (!alive) return;
+        setErr(e?.message || "Failed to load products");
+        setItems([]);
+        setTotal(0);
+      })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [query]);
 
   return (
     <div className="container">
@@ -34,10 +69,12 @@ export default function CategoryPage({category}:{category:CategoryKey}){
         <FiltersSidebar value={filters} onChange={setFilters}/>
         <div style={{display:"grid", gap:12}}>
           <SortBar total={total} sort={sort} onSort={setSort} view={view} onView={setView}/>
-          {loading ? <div className="muted">Loading…</div> : (
-            <div className={view==="grid" ? "grid featured" : "list"}>
-              {items.map(p => <ProductCard key={p.id} p={p}/>)}
-            </div>
+          {loading ? <div className="muted">Loading…</div> : err ? <div className="error">{err}</div> : (
+            items.length ? (
+              <div className={view==="grid" ? "grid featured" : "list"}>
+                {items.map(p => <ProductCard key={p.id} p={p}/>)}
+              </div>
+            ) : <div>No products found</div>
           )}
         </div>
       </div>

--- a/frontend/src/pages/category/ProductCard.tsx
+++ b/frontend/src/pages/category/ProductCard.tsx
@@ -1,4 +1,4 @@
-import type { Product } from "./types";
+import type { Product } from "../../lib/types";
 import { addToCart, removeFromCart, inCart, qtyOf, setQty } from "../../store/cart";
 
 export default function ProductCard({p}:{p:Product}){
@@ -8,21 +8,34 @@ export default function ProductCard({p}:{p:Product}){
     <div className="card" style={{padding:12}}>
       <div style={{position:"relative"}}>
         {p.discount ? <span className="badge-tag">-{p.discount}%</span> : null}
-        <img src={p.img || "/assets/images/placeholder.webp"} alt={p.name} loading="lazy" style={{width:"100%",height:180,objectFit:"cover",borderRadius:12}}/>
+        <img
+          src={p.img || "/assets/images/placeholder.webp"}
+          alt={p.name}
+          loading="lazy"
+          style={{width:"100%",height:180,objectFit:"cover",borderRadius:12}}
+        />
         {p.platform && <span className="badge-tag top-right">{p.platform}</span>}
       </div>
       <div style={{marginTop:10, fontWeight:600}}>{p.name}</div>
       <div className="muted" style={{display:"flex", gap:8, alignItems:"center", margin:"4px 0"}}>
-        <span>★ {p.rating.toFixed(1)}</span>
+        <span>★ {(p.rating ?? 0).toFixed(1)}</span>
         {p.instant && <span className="chip">Instant</span>}
       </div>
       <div style={{display:"flex", gap:8, alignItems:"baseline"}}>
         <div style={{fontWeight:700}}>${p.price}</div>
-        {p.oldPrice ? <div className="muted" style={{textDecoration:"line-through"}}>${p.oldPrice}</div> : null}
+        {p.oldPrice ? (
+          <div className="muted" style={{textDecoration:"line-through"}}>${p.oldPrice}</div>
+        ) : null}
       </div>
 
       {!added ? (
-        <button className="btn primary" style={{marginTop:10}} onClick={()=>addToCart({id:p.id,name:p.name,price:p.price,img:p.img})}>Add to Cart</button>
+        <button
+          className="btn primary"
+          style={{marginTop:10}}
+          onClick={()=>addToCart({id:p.id,name:p.name,price:p.price,img:p.img})}
+        >
+          Add to Cart
+        </button>
       ) : (
         <div style={{marginTop:10, display:"grid", gap:8}}>
           <div className="qtyrow">

--- a/frontend/src/pages/category/types.ts
+++ b/frontend/src/pages/category/types.ts
@@ -1,14 +1,1 @@
-export type Product = {
-  id: string;
-  name: string;
-  img?: string;
-  price: number;
-  oldPrice?: number;
-  rating: number;          // 0..5
-  reviews?: number;
-  platform?: "XBOX"|"PLAYSTATION"|"STEAM"|"US"|"GLOBAL"|"APPLE"|"GOOGLE";
-  instant?: boolean;
-  discount?: number;       // у %
-  region?: string;         // US/EU/UA/...
-};
 export type CategoryKey = "gaming"|"streaming"|"shopping"|"music"|"fooddrink"|"travel";


### PR DESCRIPTION
## Summary
- add shared product types
- load catalog products from backend API with filters
- handle loading and error states

## Testing
- `/usr/bin/npm test` *(fails: No such file or directory)*
- `/usr/bin/npm run build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b01aa23da0832b922a7048ff91d43d