### PR TITLE
Backend: add Bamboo adapter and /api/cards endpoint

### DIFF
--- a/routers/cards.js
+++ b/routers/cards.js
@@ -1,0 +1,66 @@
+import express from "express";
+import { bambooFetch, mapProduct } from "../utils/bamboo.js";
+
+const router = express.Router();
+
+/**
+ * GET /api/cards
+ * query: category, q, sort (popular|priceAsc|priceDesc|ratingDesc),
+ *        regions (comma), inStock (1|0), page, limit
+ */
+router.get("/", async (req, res) => {
+  try {
+    const {
+      category,
+      q,
+      sort,
+      regions,
+      inStock,
+      page = "1",
+      limit = "24",
+    } = req.query;
+
+    // Параметри для Bamboo (підлаштуй під реальне API Bamboo)
+    const params = {
+      category,
+      search: q,
+      inStock: inStock ? "true" : undefined,
+      regions,          // якщо Bamboo приймає CSV
+      page,
+      limit,
+    };
+
+    // 1) Тягнемо з Bamboo
+    const data = await bambooFetch("/products", params);
+    // Очікуємо data.items або data.products — підлаштуй!
+    const raw = Array.isArray(data?.items) ? data.items :
+                Array.isArray(data?.products) ? data.products :
+                Array.isArray(data) ? data : [];
+
+    // 2) Мапимо під фронт
+    let products = raw.map(mapProduct);
+
+    // 3) Досортування, якщо Bamboo не сортує
+    if (sort === "priceAsc")   products.sort((a,b)=> (a.price||0) - (b.price||0));
+    if (sort === "priceDesc")  products.sort((a,b)=> (b.price||0) - (a.price||0));
+    if (sort === "ratingDesc") products.sort((a,b)=> (b.rating||0) - (a.rating||0));
+    // popular — залиш як дає Bamboo (або за reviews)
+
+    // 4) Серверний фільтр за регіонами (якщо Bamboo це ігнорує)
+    if (regions) {
+      const set = new Set(String(regions).split(",").map(s=>s.trim().toUpperCase()));
+      products = products.filter(p => !p.region || set.has(String(p.region).toUpperCase()));
+    }
+
+    res.json({
+      products,
+      total: Number.isFinite(+data?.total) ? +data.total : products.length,
+    });
+  } catch (e) {
+    console.error("GET /api/cards error:", e?.message || e);
+    res.json({ products: [], total: 0 }); // graceful fallback
+  }
+});
+
+export default router;
+

--- a/server.mjs
+++ b/server.mjs
@@ -2,11 +2,13 @@ import express from "express";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
+import cardsRouter from "./routers/cards.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
+app.use(express.json());
 
 const envDist = process.env.DIST_DIR && path.resolve(process.env.DIST_DIR);
 const candidates = [
@@ -27,6 +29,8 @@ if (found) {
 } else {
   console.error("❌ dist/index.html not found. Ensure build step creates it in the repo root or set DIST_DIR.");
 }
+
+app.use("/api/cards", cardsRouter);
 
 app.get("/healthz", (_req, res) => res.status(200).send("OK"));
 

--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -1,0 +1,43 @@
+import crypto from "crypto";
+
+const BAMBOO_BASE = process.env.BAMBOO_BASE || "https://api.bamboo.example";
+const BAMBOO_KEY  = process.env.BAMBOO_API_KEY || "";
+
+const safeN = (n, d=0) => (Number.isFinite(+n) ? +n : d);
+
+export async function bambooFetch(path, params={}) {
+  const url = new URL(`${BAMBOO_BASE}${path}`);
+  Object.entries(params).forEach(([k,v]) => {
+    if (v !== undefined && v !== null && v !== "") url.searchParams.set(k, v);
+  });
+
+  const res = await fetch(url, {
+    headers: {
+      "Accept": "application/json",
+      "Authorization": BAMBOO_KEY ? `Bearer ${BAMBOO_KEY}` : undefined,
+    }
+  });
+  if (!res.ok) {
+    const t = await res.text().catch(()=> "");
+    throw new Error(`Bamboo ${res.status}: ${t || res.statusText}`);
+  }
+  return res.json();
+}
+
+/** Мапимо товар Bamboo → наш фронтовий формат */
+export function mapProduct(x) {
+  return {
+    id: String(x.id ?? x.sku ?? x.code ?? crypto.randomUUID()),
+    name: String(x.name ?? x.title ?? "Untitled"),
+    img: x.image_url || x.img || x.thumbnail || undefined,
+    price: safeN(x.price ?? x.currentPrice ?? x.amount, 0),
+    oldPrice: x.oldPrice ? safeN(x.oldPrice, 0) : undefined,
+    rating: x.rating ? safeN(x.rating, 0) : undefined,
+    reviews: x.reviews ? safeN(x.reviews, 0) : undefined,
+    platform: x.platform || x.vendor || undefined,
+    instant: x.instant ?? true,
+    discount: x.discount ? safeN(x.discount, 0) : undefined,
+    region: x.region || x.country || "US",
+  };
+}
+


### PR DESCRIPTION
## Summary
- add Bamboo helper for fetching and mapping products
- implement /api/cards endpoint with query support and graceful fallbacks
- hook cards router into Express server

## Testing
- `node server.mjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b020153a10832b8f88a95617cfc56e