### PR TITLE
feat: load category data from backend

### DIFF
--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -2,14 +2,27 @@ import { api } from "./api";
 import type { ProductsResponse } from "./types";
 
 export const Catalog = {
-  list: async (params: { category?: string; q?: string; sort?: string; regions?: string[]; inStock?: boolean }) => {
-    const query = new URLSearchParams();
-    if (params.category) query.set("category", params.category);
-    if (params.q) query.set("q", params.q);
-    if (params.sort) query.set("sort", params.sort);
-    if (params.regions?.length) query.set("regions", params.regions.join(","));
-    if (typeof params.inStock === "boolean") query.set("inStock", String(params.inStock));
-    const qs = query.toString();
-    return api.get<ProductsResponse>(`/cards${qs ? `?${qs}` : ""}`);
+  list: (p: {
+    category: string;
+    platform?: string;
+    regions?: string[];
+    denoms?: number[];
+    q?: string;
+    sort?: string;
+    inStock?: boolean;
+    page?: number;
+    limit?: number;
+  }) => {
+    const qs = new URLSearchParams();
+    qs.set("category", p.category);
+    if (p.platform) qs.set("platform", p.platform);
+    if (p.regions?.length) qs.set("regions", p.regions.join(","));
+    if (p.denoms?.length) qs.set("denoms", p.denoms.join(","));
+    if (p.q) qs.set("q", p.q);
+    if (p.sort) qs.set("sort", p.sort);
+    if (p.inStock) qs.set("inStock", "1");
+    if (p.page) qs.set("page", String(p.page));
+    if (p.limit) qs.set("limit", String(p.limit));
+    return api.get<ProductsResponse>(`/cards?${qs.toString()}`);
   },
 };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,13 +6,21 @@ export type Product = {
   oldPrice?: number;
   rating?: number;
   reviews?: number;
-  platform?: string;   // e.g. STEAM/PLAYSTATION
+  platform?: "XBOX"|"PLAYSTATION"|"STEAM"|string;
   instant?: boolean;
-  discount?: number;   // %
-  region?: string;     // e.g. US
+  discount?: number;
+  region?: string;
+  denomination?: number;
+};
+
+export type Facets = {
+  platforms?: string[];
+  regions?: string[];
+  denominations?: number[];
 };
 
 export type ProductsResponse = {
   products: Product[];
   total: number;
+  facets?: Facets;
 };

--- a/frontend/src/pages/category/FiltersSidebar.tsx
+++ b/frontend/src/pages/category/FiltersSidebar.tsx
@@ -1,17 +1,42 @@
-import { useMemo } from "react";
-export type Filters = { platform: string; regions: Record<string,boolean>; inStock: boolean };
-export default function FiltersSidebar({value,onChange}:{value:Filters; onChange:(f:Filters)=>void}){
+import type { Facets } from "../../lib/types";
+export type Filters = { inStock: boolean };
+export default function FiltersSidebar({
+  value,
+  onChange,
+  platform,
+  onPlatform,
+  regions,
+  onRegions,
+  denoms,
+  onDenoms,
+  facets,
+}:{
+  value: Filters;
+  onChange: (f: Filters) => void;
+  platform: string;
+  onPlatform: (p: string) => void;
+  regions: string[];
+  onRegions: (r: string[]) => void;
+  denoms: number[];
+  onDenoms: (d: number[]) => void;
+  facets: Facets;
+}){
   const change = (patch:Partial<Filters>) => onChange({...value, ...patch});
-  const platforms = ["All Platforms","Xbox","PlayStation","Steam"];
-  const regions = useMemo(()=>["US","EU","UA","PL","NL","DE","CA"],[]);
+  const platforms = facets.platforms?.length ? facets.platforms : ["XBOX","PLAYSTATION","STEAM"];
+  const toggleRegion = (r:string) => {
+    onRegions(regions.includes(r) ? regions.filter(x=>x!==r) : [...regions,r]);
+  };
+  const toggleDenom = (d:number) => {
+    onDenoms(denoms.includes(d) ? denoms.filter(x=>x!==d) : [...denoms,d]);
+  };
   return (
     <aside className="card" style={{padding:16, position:"sticky", top:86}}>
       <div className="f-title">Gaming Platform</div>
       <div className="f-stack">
         {platforms.map(p=>(
           <button key={p}
-            className={"f-pill" + (value.platform===p ? " active":"")}
-            onClick={()=>change({platform:p})}
+            className={"f-pill" + (platform===p ? " active":"")}
+            onClick={()=>onPlatform(p)}
           >{p}</button>
         ))}
       </div>
@@ -22,18 +47,39 @@ export default function FiltersSidebar({value,onChange}:{value:Filters; onChange
         <span>In Stock Only</span>
       </label>
 
-      <div className="f-title" style={{marginTop:18}}>Region</div>
-      <div className="f-list">
-        {regions.map(r=>(
-          <label key={r} className="f-check">
-            <input type="checkbox"
-              checked={value.regions[r] ?? false}
-              onChange={e=>change({regions:{...value.regions,[r]:e.target.checked}})}
-            />
-            <span>{r}</span>
-          </label>
-        ))}
-      </div>
+      {facets.regions?.length ? (
+        <>
+          <div className="f-title" style={{marginTop:18}}>Region</div>
+          <div className="f-list">
+            {facets.regions.map(r=>(
+              <label key={r} className="f-check">
+                <input type="checkbox"
+                  checked={regions.includes(r)}
+                  onChange={()=>toggleRegion(r)}
+                />
+                <span>{r}</span>
+              </label>
+            ))}
+          </div>
+        </>
+      ) : null}
+
+      {facets.denominations?.length ? (
+        <>
+          <div className="f-title" style={{marginTop:18}}>Denomination</div>
+          <div className="f-list">
+            {facets.denominations.map(d=>(
+              <label key={d} className="f-check">
+                <input type="checkbox"
+                  checked={denoms.includes(d)}
+                  onChange={()=>toggleDenom(d)}
+                />
+                <span>{d}</span>
+              </label>
+            ))}
+          </div>
+        </>
+      ) : null}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- fetch catalog products and facets via new catalog service
- add platform, region and denomination filters to gaming category page
- support backend facets-driven filters in sidebar

## Testing
- `npm --prefix frontend run build` *(fails: vite: not found)*
- `npm --prefix frontend test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b02e53a4e4832b90650978302b7289