### PR TITLE
Backend: /api/cards returns Bamboo products with markup + facets

### DIFF
--- a/routers/cards.js
+++ b/routers/cards.js
@@ -1,64 +1,107 @@
 import express from "express";
-import { bambooFetch, mapProduct } from "../utils/bamboo.js";
+import { bambooFetch } from "../utils/bamboo.js";
+import { applyMarkup } from "../utils/markup.js";
 
 const router = express.Router();
 
+function uniq(arr) {
+  return [...new Set(arr.filter(Boolean))];
+}
+
+function safeN(n, d = 0) {
+  n = +n;
+  return Number.isFinite(n) ? n : d;
+}
+
 /**
  * GET /api/cards
- * query: category, q, sort (popular|priceAsc|priceDesc|ratingDesc),
- *        regions (comma), inStock (1|0), page, limit
+ * query: category, platform, regions, denoms, q, sort (priceAsc|priceDesc|ratingDesc),
+ *        inStock (1|0), page, limit
  */
 router.get("/", async (req, res) => {
   try {
     const {
       category,
+      platform,
+      regions,
+      denoms,
       q,
       sort,
-      regions,
       inStock,
       page = "1",
       limit = "24",
     } = req.query;
 
-    // Параметри для Bamboo (підлаштуй під реальне API Bamboo)
     const params = {
       category,
       search: q,
+      platform,
+      regions,
+      denoms,
       inStock: inStock ? "true" : undefined,
-      regions,          // якщо Bamboo приймає CSV
       page,
       limit,
     };
 
-    // 1) Тягнемо з Bamboo
     const data = await bambooFetch("/products", params);
-    // Очікуємо data.items або data.products — підлаштуй!
-    const raw = Array.isArray(data?.items) ? data.items :
-                Array.isArray(data?.products) ? data.products :
-                Array.isArray(data) ? data : [];
+    const raw = Array.isArray(data?.items)
+      ? data.items
+      : Array.isArray(data?.products)
+        ? data.products
+        : Array.isArray(data)
+          ? data
+          : [];
 
-    // 2) Мапимо під фронт
-    let products = raw.map(mapProduct);
+    let products = raw.map((x) => {
+      const basePrice = safeN(x.price ?? x.currentPrice ?? x.amount, 0);
+      const marked = applyMarkup ? applyMarkup(basePrice, x) : basePrice;
+      return {
+        id: String(x.id ?? x.sku ?? x.code),
+        name: String(x.name ?? x.title ?? "Untitled"),
+        img: x.image_url || x.img || x.thumbnail,
+        price: marked,
+        oldPrice: basePrice && marked < basePrice ? basePrice : undefined,
+        rating: safeN(x.rating, 0),
+        reviews: safeN(x.reviews, 0),
+        platform: String(x.platform || x.vendor || "").toUpperCase(),
+        instant: true,
+        discount: x.discount ? safeN(x.discount, 0) : undefined,
+        region: x.region || x.country || "US",
+        denomination: safeN(x.denomination || x.faceValue, undefined),
+      };
+    });
 
-    // 3) Досортування, якщо Bamboo не сортує
-    if (sort === "priceAsc")   products.sort((a,b)=> (a.price||0) - (b.price||0));
-    if (sort === "priceDesc")  products.sort((a,b)=> (b.price||0) - (a.price||0));
-    if (sort === "ratingDesc") products.sort((a,b)=> (b.rating||0) - (a.rating||0));
-    // popular — залиш як дає Bamboo (або за reviews)
-
-    // 4) Серверний фільтр за регіонами (якщо Bamboo це ігнорує)
+    if (platform) {
+      const p = String(platform).toUpperCase();
+      products = products.filter((it) => (it.platform || "").toUpperCase() === p);
+    }
     if (regions) {
-      const set = new Set(String(regions).split(",").map(s=>s.trim().toUpperCase()));
-      products = products.filter(p => !p.region || set.has(String(p.region).toUpperCase()));
+      const set = new Set(String(regions).split(",").map((s) => s.trim().toUpperCase()));
+      products = products.filter((it) => !it.region || set.has(String(it.region).toUpperCase()));
+    }
+    if (denoms) {
+      const setD = new Set(String(denoms).split(",").map((s) => +s));
+      products = products.filter((it) => (it.denomination ? setD.has(+it.denomination) : false));
     }
 
-    res.json({
-      products,
-      total: Number.isFinite(+data?.total) ? +data.total : products.length,
-    });
+    if (sort === "priceAsc") products.sort((a, b) => (a.price || 0) - (b.price || 0));
+    if (sort === "priceDesc") products.sort((a, b) => (b.price || 0) - (a.price || 0));
+    if (sort === "ratingDesc") products.sort((a, b) => (b.rating || 0) - (a.rating || 0));
+
+    const facets = {
+      platforms: uniq(products.map((p) => p.platform)),
+      regions: uniq(products.map((p) => p.region)),
+      denominations: uniq(products.map((p) => p.denomination)).sort((a, b) => a - b),
+    };
+
+    res.json({ products, total: products.length, facets });
   } catch (e) {
-    console.error("GET /api/cards error:", e?.message || e);
-    res.json({ products: [], total: 0 }); // graceful fallback
+    console.error("GET /api/cards", e?.message || e);
+    res.json({
+      products: [],
+      total: 0,
+      facets: { platforms: [], regions: [], denominations: [] },
+    });
   }
 });
 

--- a/utils/markup.js
+++ b/utils/markup.js
@@ -1,0 +1,9 @@
+const DEFAULT_MARKUP = Number.parseFloat(process.env.PRICE_MARGIN || "0.1");
+
+export function applyMarkup(price, _product) {
+  const base = Number(price);
+  if (!Number.isFinite(base)) return 0;
+  return Number((base * (1 + DEFAULT_MARKUP)).toFixed(2));
+}
+
+export default { applyMarkup };


### PR DESCRIPTION
## Summary
- apply markup to Bamboo products and expose platform/region/denomination facets
- fetch products with filtering for category, platform, regions, denoms, query, sort, and stock

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b02febc57c832b91e297c198d62981