### PR TITLE
Payment: use only LiqPay (Visa/Mastercard) & redirect on checkout

### DIFF
--- a/frontend/src/lib/payment.ts
+++ b/frontend/src/lib/payment.ts
@@ -1,0 +1,35 @@
+import { api } from "./api";
+
+interface CartItem {
+  id: string;
+  qty: number;
+}
+
+interface QuotePayload {
+  items: CartItem[];
+  currency: string;
+  coupon?: string;
+}
+
+export interface QuoteResponse {
+  sub: number;
+  discount: number;
+  txn: number;
+  total: number;
+}
+
+export const getQuote = (payload: QuotePayload) =>
+  api.post<QuoteResponse>("/checkout/quote", payload);
+
+interface SessionPayload extends QuotePayload {
+  method: "liqpay";
+  email: string;
+}
+
+interface SessionResponse {
+  redirectUrl?: string;
+}
+
+export const createSession = (payload: SessionPayload) =>
+  api.post<SessionResponse>("/checkout/create-session", payload);
+


### PR DESCRIPTION
## Summary
- simplify checkout to one LiqPay button
- fetch totals via `/api/checkout/quote`
- create session and redirect to LiqPay using `/api/checkout/create-session`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b92193c832bb71307f3cec29f7f