### PR TITLE
feat: add sample gaming data fallback

### DIFF
--- a/data/sample-products.json
+++ b/data/sample-products.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "xbox-us-10",
+    "name": "Xbox Gift Card $10",
+    "price": 10,
+    "platform": "XBOX",
+    "region": "US",
+    "denomination": 10,
+    "image_url": "https://via.placeholder.com/300x180?text=XBOX10"
+  },
+  {
+    "id": "playstation-us-20",
+    "name": "PlayStation Store Card $20",
+    "price": 20,
+    "platform": "PLAYSTATION",
+    "region": "US",
+    "denomination": 20,
+    "image_url": "https://via.placeholder.com/300x180?text=PS20"
+  },
+  {
+    "id": "steam-eu-50",
+    "name": "Steam Wallet €50",
+    "price": 50,
+    "platform": "STEAM",
+    "region": "EU",
+    "denomination": 50,
+    "image_url": "https://via.placeholder.com/300x180?text=STEAM50"
+  }
+]


### PR DESCRIPTION
## Summary
- serve sample gaming products when Bamboo API is unreachable
- include Xbox, PlayStation and Steam vouchers with regions and denominations

## Testing
- `npm test`
- `node server.mjs & pid=$!; sleep 2; curl -s http://localhost:3000/api/cards?category=gaming | head -n 20; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_68b040daadb0832b8950457c89e86d87