### PR TITLE
feat: add Bamboo gift card search

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import CartIcon from "./icons/CartIcon";
 import { LanguageMenu, CurrencyMenu } from "./menus/LanguageCurrencyMenu";
 import { useEffect, useState } from "react";
@@ -8,6 +8,8 @@ export default function Header(){
   const [lang,setLang] = useState("EN");
   const [cur,setCur] = useState(localStorage.getItem("dg_currency") || "USD");
   const [count,setCount] = useState(0);
+  const [query,setQuery] = useState("");
+  const navigate = useNavigate();
   useEffect(()=>{
     setCount(totalCount());
     const t=setInterval(()=>setCount(totalCount()),800);
@@ -20,7 +22,22 @@ export default function Header(){
       <div className="topbar">
         <div className="container topbar-inner">
           <Link to="/" className="brand">DigiGames</Link>
-          <div className="search"><input placeholder="Search gift cards..." /></div>
+          <div className="search"><input
+            placeholder="Search gift cards..."
+            value={query}
+            onChange={e=>setQuery(e.target.value)}
+            onKeyDown={async e=>{
+              if(e.key!=="Enter"||!query.trim()) return;
+              try{
+                const res=await fetch(`/api/cards?q=${encodeURIComponent(query.trim())}`);
+                const data=await res.json();
+                const cat=data.products?.[0]?.category||"gaming";
+                navigate(`/${cat}?q=${encodeURIComponent(query.trim())}`);
+              }catch(err){
+                console.error("search",err);
+              }
+            }}
+          /></div>
           <nav className="topnav" aria-label="Actions">
             <LanguageMenu value={lang} onChange={setLang}/>
             <CurrencyMenu value={cur} onChange={setCur}/>

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import CategoryBanner from "./CategoryBanner";
 import FiltersSidebar, { Filters } from "./FiltersSidebar";
 import SortBar from "./SortBar";
@@ -19,14 +20,16 @@ export default function CategoryPage({category}:{category:CategoryKey}){
   const [regions,setRegions] = useState<string[]>([]);
   const [denoms,setDenoms] = useState<number[]>([]);
   const [facets,setFacets] = useState<Facets>({});
+  const loc = useLocation();
+  const q = new URLSearchParams(loc.search).get("q") || "";
 
   useEffect(()=>{
     setLoading(true);
-    Catalog.list({ category, platform, regions, denoms, sort, inStock: filters.inStock })
+    Catalog.list({ category, platform, regions, denoms, sort, inStock: filters.inStock, q })
       .then(res => { setItems(res.products||[]); setTotal(res.total||0); setFacets(res.facets||{}); })
       .catch(()=>{ setItems([]); setTotal(0); })
       .finally(()=> setLoading(false));
-  }, [category, platform, regions.join(","), denoms.join(","), sort, filters.inStock]);
+  }, [category, platform, regions.join(","), denoms.join(","), sort, filters.inStock, q]);
 
   return (
     <div className="container">

--- a/routers/cards.js
+++ b/routers/cards.js
@@ -13,6 +13,23 @@ function safeN(n, d = 0) {
   return Number.isFinite(n) ? n : d;
 }
 
+function categorize(x) {
+  const raw = String(x.category || x.categories || "").toLowerCase();
+  if (raw.includes("gaming")) return "gaming";
+  if (raw.includes("stream")) return "streaming";
+  if (raw.includes("music")) return "music";
+  if (raw.includes("food") || raw.includes("drink")) return "fooddrink";
+  if (raw.includes("travel")) return "travel";
+  if (raw.includes("shop")) return "shopping";
+  const guess = String(x.platform || x.vendor || x.name || "").toLowerCase();
+  if (/xbox|playstation|steam|nintendo|game/.test(guess)) return "gaming";
+  if (/netflix|hulu|disney|prime|stream/.test(guess)) return "streaming";
+  if (/spotify|itunes|music|apple/.test(guess)) return "music";
+  if (/uber|doordash|food|drink|restaurant/.test(guess)) return "fooddrink";
+  if (/air|hotel|travel|flight/.test(guess)) return "travel";
+  return "shopping";
+}
+
 /**
  * GET /api/cards
  * query: category, platform, regions, denoms, q, sort (priceAsc|priceDesc|ratingDesc),
@@ -68,6 +85,7 @@ router.get("/", async (req, res) => {
         discount: x.discount ? safeN(x.discount, 0) : undefined,
         region: x.region || x.country || "US",
         denomination: safeN(x.denomination || x.faceValue, undefined),
+        category: categorize(x),
       };
     });
 

--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -8,6 +8,23 @@ const BAMBOO_KEY  = process.env.BAMBOO_API_KEY || "";
 
 const safeN = (n, d=0) => (Number.isFinite(+n) ? +n : d);
 
+function categorize(x) {
+  const raw = String(x.category || x.categories || "").toLowerCase();
+  if (raw.includes("gaming")) return "gaming";
+  if (raw.includes("stream")) return "streaming";
+  if (raw.includes("music")) return "music";
+  if (raw.includes("food") || raw.includes("drink")) return "fooddrink";
+  if (raw.includes("travel")) return "travel";
+  if (raw.includes("shop")) return "shopping";
+  const guess = String(x.platform || x.vendor || x.name || "").toLowerCase();
+  if (/xbox|playstation|steam|nintendo|game/.test(guess)) return "gaming";
+  if (/netflix|hulu|disney|prime|stream/.test(guess)) return "streaming";
+  if (/spotify|itunes|music|apple/.test(guess)) return "music";
+  if (/uber|doordash|food|drink|restaurant/.test(guess)) return "fooddrink";
+  if (/air|hotel|travel|flight/.test(guess)) return "travel";
+  return "shopping";
+}
+
 function loadSampleProducts() {
   try {
     const __filename = fileURLToPath(import.meta.url);
@@ -59,6 +76,7 @@ export function mapProduct(x) {
     instant: x.instant ?? true,
     discount: x.discount ? safeN(x.discount, 0) : undefined,
     region: x.region || x.country || "US",
+    category: categorize(x),
   };
 }
 


### PR DESCRIPTION
## Summary
- categorize Bamboo products into site sections
- enable search bar to fetch and navigate to matching category
- support query-driven product listing in category pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b04a47c9d4832ba80e74ec252d148d