### PR TITLE
feat: add search endpoint with auto categorization

### DIFF
--- a/routers/search.js
+++ b/routers/search.js
@@ -1,0 +1,64 @@
+import express from "express";
+import { fetchBambooProducts } from "../utils/bamboo.js";
+import { applyMarkup } from "../utils/markup.js";
+
+const router = express.Router();
+const N = (x, d = 0) => (Number.isFinite(+x) ? +x : d);
+
+function autoCategory(x) {
+  const name = String(x.name || "").toLowerCase();
+  const plat = String(x.platform || x.vendor || "").toUpperCase();
+  if (
+    ["XBOX", "PLAYSTATION", "STEAM", "NINTENDO"].includes(plat) ||
+    /xbox|playstation|psn|steam|nintendo|game/.test(name)
+  )
+    return "gaming";
+  if (
+    /netflix|spotify|hulu|disney|hbo|max|prime video|youtube|twitch/.test(
+      name
+    )
+  )
+    return "streaming";
+  if (/apple music|spotify|deezer|tidal|music/.test(name)) return "music";
+  if (/uber|airbnb|booking|bolt|lyft|travel/.test(name)) return "travel";
+  if (/starbucks|ubereats|doordash|grubhub|food|drink/.test(name))
+    return "fooddrink";
+  if (/amazon|ebay|target|aliexpress|walmart|shopping/.test(name))
+    return "shopping";
+  return "shopping";
+}
+
+router.get("/", async (req, res) => {
+  const { q, page = "1", limit = "24" } = req.query;
+  if (!q || String(q).trim().length < 2)
+    return res.json({ products: [], total: 0 });
+  try {
+    const raw = await fetchBambooProducts({ search: q, page, limit });
+    const products = raw.map((x) => {
+      const base = N(x.price ?? x.currentPrice ?? x.amount, 0);
+      const price = applyMarkup(base, x);
+      const name = String(x.name ?? x.title ?? "Untitled").slice(0, 200);
+      const imgRaw = x.image_url || x.img || x.thumbnail || "";
+      const img = imgRaw ? String(imgRaw).slice(0, 500) : undefined;
+      return {
+        id: String(x.id ?? x.sku ?? x.code),
+        name,
+        img,
+        price,
+        oldPrice: base && price < base ? base : undefined,
+        category: autoCategory(x),
+        platform: String(x.platform || x.vendor || "").toUpperCase(),
+        region: x.region || x.country || "US",
+        denomination: N(x.denomination ?? x.faceValue, undefined),
+        rating: N(x.rating, 0),
+        reviews: N(x.reviews, 0),
+      };
+    });
+    res.json({ products, total: products.length });
+  } catch (e) {
+    console.error("[/api/search]", e?.message || e);
+    res.json({ products: [], total: 0, error: true });
+  }
+});
+
+export default router;

--- a/server.mjs
+++ b/server.mjs
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import cardsRouter from "./routers/cards.js";
+import searchRouter from "./routers/search.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,6 +31,7 @@ if (found) {
   console.error("❌ dist/index.html not found. Ensure build step creates it in the repo root or set DIST_DIR.");
 }
 
+app.use("/api/search", searchRouter);
 app.use("/api/cards", cardsRouter);
 
 app.get("/healthz", (_req, res) => res.status(200).send("OK"));


### PR DESCRIPTION
## Summary
- add `/api/search` endpoint querying Bamboo and applying markup
- auto-categorize products by platform/name keywords
- expose search route via server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b05219874c832b970f01a5d2cc4973