### PR TITLE
Frontend search: connect header input to /api/search and render results grid

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage"; // Figma Home
 import CategoryPage from "./pages/category/CategoryPage";
+import SearchPage from "./pages/search/SearchPage";
 import AboutUsPage from "./components/AboutUsPage";
 import ContactPage from "./components/ContactPage";
 import FAQPage from "./components/FAQPage";
@@ -21,6 +22,7 @@ export default function App(){
           <Route path="/music" element={<CategoryPage category="music"/>}/>
           <Route path="/fooddrink" element={<CategoryPage category="fooddrink"/>}/>
           <Route path="/travel" element={<CategoryPage category="travel"/>}/>
+          <Route path="/search" element={<SearchPage/>}/>
           <Route path="/about" element={<AboutUsPage/>}/>
           <Route path="/contact" element={<ContactPage/>}/>
           <Route path="/faq" element={<FAQPage/>}/>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -29,22 +29,21 @@ export default function Header(){
       <div className="topbar">
         <div className="container topbar-inner">
           <Link to="/" className="brand">DigiGames</Link>
-          <div className="search"><input
-            placeholder="Search gift cards..."
-            value={query}
-            onChange={e=>setQuery(e.target.value)}
-            onKeyDown={async e=>{
-              if(e.key!=="Enter"||!query.trim()) return;
-              try{
-                const res=await fetch(`/api/cards?q=${encodeURIComponent(query.trim())}&currency=${encodeURIComponent(cur)}&lang=${encodeURIComponent(lang)}`);
-                const data=await res.json();
-                const cat=data.products?.[0]?.category||"gaming";
-                navigate(`/${cat}?q=${encodeURIComponent(query.trim())}`);
-              }catch(err){
-                console.error("search",err);
-              }
-            }}
-          /></div>
+          <div className="search">
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+                if (!query.trim()) return;
+                navigate(`/search?q=${encodeURIComponent(query.trim())}`);
+              }}
+            >
+              <input
+                placeholder="Search gift cards..."
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+              />
+            </form>
+          </div>
           <nav className="topnav" aria-label="Actions">
             <LanguageMenu value={lang} onChange={setLang}/>
             <CurrencyMenu value={cur} onChange={setCur}/>

--- a/frontend/src/components/ProductCard.ts
+++ b/frontend/src/components/ProductCard.ts
@@ -1,0 +1,1 @@
+export { default as ProductCard } from "../pages/category/ProductCard";

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -1,0 +1,8 @@
+import { api } from "./api";
+
+export const Search = {
+  find: (q: string, p: { page?: number; limit?: number } = {}) =>
+    api.get<{ products: any[]; total: number }>(
+      `/search?q=${encodeURIComponent(q)}&page=${p.page || 1}&limit=${p.limit || 24}`
+    ),
+};

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,7 @@ export type Product = {
   img?: string;
   price: number;
   oldPrice?: number;
+  category?: string;
   rating?: number;
   reviews?: number;
   platform?: "XBOX"|"PLAYSTATION"|"STEAM"|string;

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import CategoryBanner from "./CategoryBanner";
 import FiltersSidebar, { Filters } from "./FiltersSidebar";
 import SortBar from "./SortBar";
-import ProductCard from "./ProductCard";
+import { ProductCard } from "../../components/ProductCard";
 import { Catalog } from "../../lib/services";
 import type { Product, Facets } from "../../lib/types";
 import type { CategoryKey } from "./types";
@@ -61,7 +61,7 @@ export default function CategoryPage({category}:{category:CategoryKey}){
           {loading ? <div className="muted">Loading…</div> : err ? <div className="error">{err}</div> : (
             items.length ? (
               <div className={view==="grid" ? "grid featured" : "list"}>
-                {items.map(p => <ProductCard key={p.id} p={p}/>)}
+                {items.map(p => <ProductCard key={p.id} product={p}/>)}
               </div>
             ) : <div>No products found</div>
           )}

--- a/frontend/src/pages/category/ProductCard.tsx
+++ b/frontend/src/pages/category/ProductCard.tsx
@@ -2,32 +2,40 @@ import type { Product } from "../../lib/types";
 import { addToCart, removeFromCart, inCart, qtyOf, setQty } from "../../store/cart";
 import { money } from "../checkout/cartUtils";
 
-export default function ProductCard({p}:{p:Product}){
+export default function ProductCard({
+  product,
+  showCategoryBadge,
+}: {
+  product: Product;
+  showCategoryBadge?: boolean;
+}) {
+  const p = product;
   const added = inCart(p.id);
   const qty = qtyOf(p.id);
   const cur = localStorage.getItem("dg_currency") || p.currency || "USD";
   return (
-    <div className="card" style={{padding:12}}>
-      <div style={{position:"relative"}}>
+    <div className="card" style={{ padding: 12 }}>
+      <div style={{ position: "relative" }}>
+        {showCategoryBadge && p.category && (
+          <span className={`badge cat-${p.category}`}>{p.category}</span>
+        )}
         {p.discount ? <span className="badge-tag">-{p.discount}%</span> : null}
         <img
           src={p.img || "/assets/images/placeholder.webp"}
           alt={p.name}
           loading="lazy"
-          style={{width:"100%",height:180,objectFit:"cover",borderRadius:12}}
+          style={{ width: "100%", height: 180, objectFit: "cover", borderRadius: 12 }}
         />
         {p.platform && <span className="badge-tag top-right">{p.platform}</span>}
       </div>
-      <div style={{marginTop:10, fontWeight:600}}>{p.name}</div>
-      <div className="muted" style={{display:"flex", gap:8, alignItems:"center", margin:"4px 0"}}>
+      <div style={{ marginTop: 10, fontWeight: 600 }}>{p.name}</div>
+      <div className="muted" style={{ display: "flex", gap: 8, alignItems: "center", margin: "4px 0" }}>
         <span>★ {(p.rating ?? 0).toFixed(1)}</span>
         {p.instant && <span className="chip">Instant</span>}
       </div>
-      <div style={{display:"flex", gap:8, alignItems:"baseline"}}>
-        <div style={{fontWeight:700}}>{money(p.price, cur)}</div>
-        {p.oldPrice ? (
-          <div className="muted" style={{textDecoration:"line-through"}}>{money(p.oldPrice, cur)}</div>
-        ) : null}
+      <div className="price" style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+        {p.oldPrice ? <s className="muted">{money(p.oldPrice, cur)}</s> : null}
+        <strong>{money(p.price, cur)}</strong>
       </div>
 
       {!added ? (

--- a/frontend/src/pages/search/SearchPage.tsx
+++ b/frontend/src/pages/search/SearchPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { Search } from "../../lib/search";
+import { ProductCard } from "../../components/ProductCard";
+import type { Product } from "../../lib/types";
+
+export default function SearchPage() {
+  const q = new URLSearchParams(useLocation().search).get("q") || "";
+  const [items, setItems] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (q.trim().length < 2) {
+      setItems([]);
+      return;
+    }
+    let alive = true;
+    setLoading(true);
+    const t = setTimeout(() => {
+      Search.find(q)
+        .then((res) => alive && setItems(res.products || []))
+        .finally(() => alive && setLoading(false));
+    }, 300);
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [q]);
+
+  return (
+    <div className="container">
+      <h1>Results for “{q}”</h1>
+      {q.trim().length < 2 ? (
+        <p>Please enter at least 2 characters to search.</p>
+      ) : loading ? (
+        <div className="skeleton-grid" />
+      ) : items.length ? (
+        <div className="grid">
+          {items.map((p) => (
+            <div key={p.id} style={{ display: "grid", gap: 8 }}>
+              <ProductCard product={p} showCategoryBadge />
+              {p.category && (
+                <Link
+                  to={`/${p.category}?highlight=${p.id}`}
+                  className="btn sm secondary"
+                >
+                  View in category
+                </Link>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>No results for “{q}”.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Search SDK and `/search` route with debounced querying and category links
- Wire header search form to navigate to `/search?q=...`
- Extend ProductCard with optional category badge and updated price display

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run build` *(fails: vite: not found)*
- `cd frontend && npm install` *(fails: 403 Forbidden for @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b052481eac832bb878b2f302daaef9