### PR TITLE
Fix search result card labels and expand search bar

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -29,8 +29,9 @@ export default function Header(){
       <div className="topbar">
         <div className="container topbar-inner">
           <Link to="/" className="brand">DigiGames</Link>
-          <div className="search">
+          <div className="search" style={{ flex: 1 }}>
             <form
+              style={{ width: "100%" }}
               onSubmit={e => {
                 e.preventDefault();
                 if (!query.trim()) return;
@@ -41,6 +42,7 @@ export default function Header(){
                 placeholder="Search gift cards..."
                 value={query}
                 onChange={e => setQuery(e.target.value)}
+                style={{ width: "100%", padding: "12px 16px", textAlign: "center" }}
               />
             </form>
           </div>

--- a/frontend/src/pages/category/ProductCard.tsx
+++ b/frontend/src/pages/category/ProductCard.tsx
@@ -13,20 +13,25 @@ export default function ProductCard({
   const added = inCart(p.id);
   const qty = qtyOf(p.id);
   const cur = localStorage.getItem("dg_currency") || p.currency || "USD";
+  const categoryLabel = p.category
+    ? p.category.charAt(0).toUpperCase() + p.category.slice(1)
+    : "";
   return (
     <div className="card" style={{ padding: 12 }}>
       <div style={{ position: "relative" }}>
-        {showCategoryBadge && p.category && (
-          <span className={`badge cat-${p.category}`}>{p.category}</span>
+        {showCategoryBadge && categoryLabel && (
+          <span className={`badge cat-${p.category}`}>{categoryLabel}</span>
         )}
         {p.discount ? <span className="badge-tag">-{p.discount}%</span> : null}
+        {!showCategoryBadge && p.platform && (
+          <span className="badge-tag top-right">{p.platform}</span>
+        )}
         <img
           src={p.img || "/assets/images/placeholder.webp"}
           alt={p.name}
           loading="lazy"
           style={{ width: "100%", height: 180, objectFit: "cover", borderRadius: 12 }}
         />
-        {p.platform && <span className="badge-tag top-right">{p.platform}</span>}
       </div>
       <div style={{ marginTop: 10, fontWeight: 600 }}>{p.name}</div>
       <div className="muted" style={{ display: "flex", gap: 8, alignItems: "center", margin: "4px 0" }}>


### PR DESCRIPTION
## Summary
- Ensure search cards display the product name and category-specific badge
- Widen header search bar with centered, padded input

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden on @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b055d7b3d8832bb3d2206744e1c2a1