### PR TITLE
Search: return only relevant matches and adjust input width

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -32,7 +32,7 @@ body{
 .topnav{display:flex;gap:12px;align-items:center}
 .search{flex:1;display:flex;justify-content:center}
 .search input{
-  width:min(560px,100%);
+  width:min(36rem,100%);
   border:1px solid var(--card-border);
   border-radius:12px;
   padding:10px 12px;

--- a/routers/search.js
+++ b/routers/search.js
@@ -5,6 +5,37 @@ import { applyMarkup } from "../utils/markup.js";
 const router = express.Router();
 const N = (x, d = 0) => (Number.isFinite(+x) ? +x : d);
 
+const score = (q, x) => {
+  const s = String(q).trim().toLowerCase();
+  const name = String(x.name || "").toLowerCase();
+  const ven = String(x.vendor || x.platform || "").toLowerCase();
+  let sc = 0;
+  if (name.includes(s)) sc += 3;
+  if (ven.includes(s)) sc += 1;
+  return sc;
+};
+
+function map(x) {
+  const base = N(x.price ?? x.currentPrice ?? x.amount, 0);
+  const price = applyMarkup(base, x);
+  const name = String(x.name ?? x.title ?? "Untitled").slice(0, 200);
+  const imgRaw = x.image_url || x.img || x.thumbnail || "";
+  const img = imgRaw ? String(imgRaw).slice(0, 500) : undefined;
+  return {
+    id: String(x.id ?? x.sku ?? x.code),
+    name,
+    img,
+    price,
+    oldPrice: base && price < base ? base : undefined,
+    category: autoCategory(x),
+    platform: String(x.platform || x.vendor || "").toUpperCase(),
+    region: x.region || x.country || "US",
+    denomination: N(x.denomination ?? x.faceValue, undefined),
+    rating: N(x.rating, 0),
+    reviews: N(x.reviews, 0),
+  };
+}
+
 function autoCategory(x) {
   const name = String(x.name || "").toLowerCase();
   const plat = String(x.platform || x.vendor || "").toUpperCase();
@@ -29,32 +60,17 @@ function autoCategory(x) {
 }
 
 router.get("/", async (req, res) => {
-  const { q, page = "1", limit = "24" } = req.query;
-  if (!q || String(q).trim().length < 2)
-    return res.json({ products: [], total: 0 });
+  const q = (req.query.q || "").trim();
+  const { page = "1", limit = "24" } = req.query;
+  if (q.length < 2) return res.json({ products: [], total: 0 });
   try {
     const raw = await fetchBambooProducts({ search: q, page, limit });
-    const products = raw.map((x) => {
-      const base = N(x.price ?? x.currentPrice ?? x.amount, 0);
-      const price = applyMarkup(base, x);
-      const name = String(x.name ?? x.title ?? "Untitled").slice(0, 200);
-      const imgRaw = x.image_url || x.img || x.thumbnail || "";
-      const img = imgRaw ? String(imgRaw).slice(0, 500) : undefined;
-      return {
-        id: String(x.id ?? x.sku ?? x.code),
-        name,
-        img,
-        price,
-        oldPrice: base && price < base ? base : undefined,
-        category: autoCategory(x),
-        platform: String(x.platform || x.vendor || "").toUpperCase(),
-        region: x.region || x.country || "US",
-        denomination: N(x.denomination ?? x.faceValue, undefined),
-        rating: N(x.rating, 0),
-        reviews: N(x.reviews, 0),
-      };
-    });
-    res.json({ products, total: products.length });
+    const withScore = raw
+      .map((x) => ({ item: map(x), sc: score(q, x) }))
+      .filter((z) => z.sc > 0)
+      .sort((a, b) => b.sc - a.sc)
+      .map((z) => z.item);
+    res.json({ products: withScore, total: withScore.length });
   } catch (e) {
     console.error("[/api/search]", e?.message || e);
     res.json({ products: [], total: 0, error: true });


### PR DESCRIPTION
## Summary
- score and filter search results so only name/vendor/platform matches are returned, sorted by relevance
- limit header search field to max width 36rem

## Testing
- `npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b05d1b1fe4832ba4d1fbbd7ce0a884