### PR TITLE
ProductCard: show product name and category badge

### DIFF
--- a/frontend/src/pages/category/ProductCard.tsx
+++ b/frontend/src/pages/category/ProductCard.tsx
@@ -4,10 +4,8 @@ import { money } from "../checkout/cartUtils";
 
 export default function ProductCard({
   product,
-  showCategoryBadge,
 }: {
   product: Product;
-  showCategoryBadge?: boolean;
 }) {
   const p = product;
   const added = inCart(p.id);
@@ -19,13 +17,7 @@ export default function ProductCard({
   return (
     <div className="card" style={{ padding: 12 }}>
       <div style={{ position: "relative" }}>
-        {showCategoryBadge && categoryLabel && (
-          <span className={`badge cat-${p.category}`}>{categoryLabel}</span>
-        )}
         {p.discount ? <span className="badge-tag">-{p.discount}%</span> : null}
-        {!showCategoryBadge && p.platform && (
-          <span className="badge-tag top-right">{p.platform}</span>
-        )}
         <img
           src={p.img || "/assets/images/placeholder.webp"}
           alt={p.name}
@@ -33,32 +25,37 @@ export default function ProductCard({
           style={{ width: "100%", height: 180, objectFit: "cover", borderRadius: 12 }}
         />
       </div>
-      <div style={{ marginTop: 10, fontWeight: 600 }}>{p.name}</div>
-      <div className="muted" style={{ display: "flex", gap: 8, alignItems: "center", margin: "4px 0" }}>
-        <span>★ {(p.rating ?? 0).toFixed(1)}</span>
-        {p.instant && <span className="chip">Instant</span>}
-      </div>
-      <div className="price" style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
-        {p.oldPrice ? <s className="muted">{money(p.oldPrice, cur)}</s> : null}
-        <strong>{money(p.price, cur)}</strong>
+      <div className="meta" style={{ marginTop: 10 }}>
+        {categoryLabel && (
+          <span className={`badge badge-${p.category}`}>{categoryLabel}</span>
+        )}
+        <h3 className="title" style={{ marginTop: 8 }}>{p.name}</h3>
+        <div className="muted" style={{ display: "flex", gap: 8, alignItems: "center", margin: "4px 0" }}>
+          <span>★ {(p.rating ?? 0).toFixed(1)}</span>
+          {p.instant && <span className="chip">Instant</span>}
+        </div>
+        <div className="price" style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+          {p.oldPrice ? <s className="muted">{money(p.oldPrice, cur)}</s> : null}
+          <strong>{money(p.price, cur)}</strong>
+        </div>
       </div>
 
       {!added ? (
         <button
           className="btn primary"
-          style={{marginTop:10}}
-          onClick={()=>addToCart({id:p.id,name:p.name,price:p.price,img:p.img})}
+          style={{ marginTop: 10 }}
+          onClick={() => addToCart({ id: p.id, name: p.name, price: p.price, img: p.img })}
         >
           Add to Cart
         </button>
       ) : (
-        <div style={{marginTop:10, display:"grid", gap:8}}>
+        <div style={{ marginTop: 10, display: "grid", gap: 8 }}>
           <div className="qtyrow">
-            <button className="btn sm" onClick={()=>setQty(p.id, Math.max(1, qty-1))}>–</button>
+            <button className="btn sm" onClick={() => setQty(p.id, Math.max(1, qty - 1))}>–</button>
             <span className="qty">{qty}</span>
-            <button className="btn sm" onClick={()=>setQty(p.id, qty+1)}>+</button>
+            <button className="btn sm" onClick={() => setQty(p.id, qty + 1)}>+</button>
           </div>
-          <button className="btn danger" onClick={()=>removeFromCart(p.id)}>Remove from Cart</button>
+          <button className="btn danger" onClick={() => removeFromCart(p.id)}>Remove from Cart</button>
         </div>
       )}
     </div>

--- a/frontend/src/pages/search/SearchPage.tsx
+++ b/frontend/src/pages/search/SearchPage.tsx
@@ -38,7 +38,7 @@ export default function SearchPage() {
         <div className="grid">
           {items.map((p) => (
             <div key={p.id} style={{ display: "grid", gap: 8 }}>
-              <ProductCard product={p} showCategoryBadge />
+              <ProductCard product={p} />
               {p.category && (
                 <Link
                   to={`/${p.category}?highlight=${p.id}`}


### PR DESCRIPTION
## Summary
- render product category badge from `product.category`
- show product name as card title and drop platform badge
- adjust search page to use updated ProductCard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b05d307620832bbb63b415734fbeb5