### PR TITLE
Fix checkout totals and LiqPay session with persisted order

### DIFF
--- a/frontend/src/lib/payment.ts
+++ b/frontend/src/lib/payment.ts
@@ -12,9 +12,10 @@ interface QuotePayload {
 }
 
 export interface QuoteResponse {
-  sub: number;
+  lines: { id: string; name: string; qty: number; unitPrice: number; lineTotal: number }[];
+  subtotal: number;
   discount: number;
-  txn: number;
+  transaction: number;
   total: number;
 }
 
@@ -27,6 +28,7 @@ interface SessionPayload extends QuotePayload {
 }
 
 interface SessionResponse {
+  sessionId: string;
   redirectUrl?: string;
 }
 

--- a/frontend/src/pages/checkout/PaymentPage.tsx
+++ b/frontend/src/pages/checkout/PaymentPage.tsx
@@ -18,7 +18,13 @@ export default function PaymentPage() {
   const [currency] = useState(getCurrency());
   const [agree, setAgree] = useState(false);
   const [code, setCode] = useState(localStorage.getItem("dg_coupon") || "");
-  const [sums, setSums] = useState({ sub: 0, discount: 0, txn: 0, total: 0 });
+  const [sums, setSums] = useState({
+    lines: [],
+    subtotal: 0,
+    discount: 0,
+    transaction: 0,
+    total: 0,
+  });
   const [creating, setCreating] = useState(false);
   const [pErr, setPErr] = useState<string | null>(null);
 
@@ -36,11 +42,17 @@ export default function PaymentPage() {
     };
     getQuote(payload)
       .then((res) => setSums(res))
-      .catch(() => setSums({ sub: 0, discount: 0, txn: 0, total: 0 }));
+      .catch(() =>
+        setSums({ lines: [], subtotal: 0, discount: 0, transaction: 0, total: 0 })
+      );
   }, [items, code, currency]);
 
   const canProceed =
-    !!email && /\S+@\S+\.\S+/.test(email) && items.length > 0 && agree;
+    !!email &&
+    /\S+@\S+\.\S+/.test(email) &&
+    items.length > 0 &&
+    agree &&
+    sums.total > 0;
 
   async function handlePay() {
     setCreating(true);
@@ -91,7 +103,7 @@ export default function PaymentPage() {
 
           <div className="co-row">
             <span>{totalCount()}× items</span>
-            <span>{money(sums.sub, currency)}</span>
+            <span>{money(sums.subtotal, currency)}</span>
           </div>
 
           <details className="discount" open={!!code}>
@@ -115,11 +127,13 @@ export default function PaymentPage() {
 
           <div className="co-row">
             <span>Subtotal</span>
-            <span>{money(Math.max(0, sums.sub - sums.discount), currency)}</span>
+            <span>
+              {money(Math.max(0, sums.subtotal - sums.discount), currency)}
+            </span>
           </div>
           <div className="co-row">
             <span>Transaction Costs</span>
-            <span>{money(sums.txn, currency)}</span>
+            <span>{money(sums.transaction, currency)}</span>
           </div>
 
           <div className="divider" />

--- a/models/Order.js
+++ b/models/Order.js
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+
+const OrderSchema = new mongoose.Schema(
+  {
+    orderId: { type: String, unique: true, index: true },
+    email: String,
+    currency: { type: String, default: "USD" },
+    items: [
+      { id: String, name: String, qty: Number, unitPrice: Number, lineTotal: Number }
+    ],
+    subtotal: Number,
+    discount: Number,
+    transaction: Number,
+    total: Number,
+    provider: { type: String, default: "liqpay" },
+    status: { type: String, enum: ["created", "paid", "failed"], default: "created" },
+    meta: Object
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model("Order", OrderSchema);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node server.mjs"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "mongoose": "^8.0.0"
   }
 }

--- a/routers/checkout.js
+++ b/routers/checkout.js
@@ -1,0 +1,92 @@
+import express from "express";
+import crypto from "crypto";
+import Order from "../models/Order.js";
+import { quote } from "../utils/pricing.js";
+
+const router = express.Router();
+const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64");
+const sha1b64 = (s) => crypto.createHash("sha1").update(s).digest("base64");
+
+router.post("/quote", async (req, res) => {
+  try {
+    res.json(
+      await quote({
+        items: req.body?.items || [],
+        coupon: req.body?.coupon,
+        method: "liqpay",
+      })
+    );
+  } catch (e) {
+    console.error("[quote]", e.message);
+    res.json({
+      lines: [],
+      subtotal: 0,
+      discount: 0,
+      transaction: 0,
+      total: 0,
+      error: true,
+    });
+  }
+});
+
+router.post("/create-session", async (req, res) => {
+  try {
+    const { items = [], currency = "USD", email } = req.body || {};
+    if (!email || !/^\S+@\S+\.\S+$/.test(email))
+      return res.status(400).json({ error: "Valid email required" });
+
+    const q = await quote({ items, method: "liqpay" });
+    if (q.total <= 0)
+      return res.status(400).json({ error: "Cart total is zero" });
+
+    const orderId = `dg_${Date.now()}_${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+
+    await Order.create({
+      orderId,
+      email,
+      currency,
+      items: q.lines,
+      subtotal: q.subtotal,
+      discount: q.discount,
+      transaction: q.transaction,
+      total: q.total,
+      provider: "liqpay",
+      status: "created",
+    });
+
+    const pub = process.env.LIQPAY_PUBLIC_KEY;
+    const prv = process.env.LIQPAY_PRIVATE_KEY;
+    if (!pub || !prv)
+      return res.status(500).json({ error: "LiqPay keys missing" });
+
+    const payload = {
+      public_key: pub,
+      version: 3,
+      action: "pay",
+      amount: q.total.toFixed(2),
+      currency,
+      description: `DigiGames order ${orderId} for ${email}`,
+      order_id: orderId,
+      result_url: process.env.PAYMENT_RESULT_URL,
+      server_url:
+        process.env.LIQPAY_SERVER_URL ||
+        (process.env.PUBLIC_URL
+          ? process.env.PUBLIC_URL + "/api/liqpay/webhook"
+          : undefined),
+      sandbox: process.env.LIQPAY_SANDBOX ? 1 : undefined,
+    };
+    const data = b64(payload);
+    const signature = sha1b64(prv + data + prv);
+    const redirectUrl = `https://www.liqpay.ua/api/3/checkout?data=${encodeURIComponent(
+      data
+    )}&signature=${encodeURIComponent(signature)}`;
+    res.json({ sessionId: orderId, redirectUrl });
+  } catch (e) {
+    console.error("[create-session]", e.message);
+    res.status(500).json({ error: "Failed to create session" });
+  }
+});
+
+export default router;

--- a/routers/liqpay.js
+++ b/routers/liqpay.js
@@ -1,0 +1,33 @@
+import express from "express";
+import crypto from "crypto";
+import Order from "../models/Order.js";
+
+const router = express.Router();
+
+router.post(
+  "/webhook",
+  express.urlencoded({ extended: true }),
+  async (req, res) => {
+    try {
+      const { data, signature } = req.body || {};
+      const prv = process.env.LIQPAY_PRIVATE_KEY;
+      const calc = crypto
+        .createHash("sha1")
+        .update(prv + data + prv)
+        .digest("base64");
+      if (calc !== signature) return res.status(403).end("bad signature");
+      const payload = JSON.parse(Buffer.from(data, "base64").toString("utf8"));
+      const ok = payload?.status === "success" || payload?.paid === 1;
+      await Order.findOneAndUpdate(
+        { orderId: payload?.order_id },
+        { status: ok ? "paid" : "failed", meta: { liqpay: payload } }
+      );
+      res.sendStatus(200);
+    } catch (e) {
+      console.error("[liqpay webhook]", e.message);
+      res.sendStatus(200);
+    }
+  }
+);
+
+export default router;

--- a/server.mjs
+++ b/server.mjs
@@ -2,14 +2,27 @@ import express from "express";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
+import mongoose from "mongoose";
 import cardsRouter from "./routers/cards.js";
 import searchRouter from "./routers/search.js";
+import checkoutRouter from "./routers/checkout.js";
+import liqpayRouter from "./routers/liqpay.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(express.json());
+
+const MONGO = process.env.MONGODB_URI;
+if (MONGO) {
+  mongoose
+    .connect(MONGO)
+    .then(() => console.log("Mongo connected"))
+    .catch((e) => console.error("Mongo connect error:", e.message));
+} else {
+  console.warn("MONGODB_URI not set");
+}
 
 const envDist = process.env.DIST_DIR && path.resolve(process.env.DIST_DIR);
 const candidates = [
@@ -33,6 +46,8 @@ if (found) {
 
 app.use("/api/search", searchRouter);
 app.use("/api/cards", cardsRouter);
+app.use("/api/checkout", express.json(), checkoutRouter);
+app.use("/api/liqpay", liqpayRouter);
 
 app.get("/healthz", (_req, res) => res.status(200).send("OK"));
 

--- a/utils/pricing.js
+++ b/utils/pricing.js
@@ -1,0 +1,35 @@
+import { fetchBambooById } from "./bamboo.js";
+import { applyMarkup } from "./markup.js";
+
+const N = (x, d = 0) => (Number.isFinite(+x) ? +x : d);
+
+async function priceFor(id, fallback) {
+  const x = await fetchBambooById(id).catch(() => null);
+  const base = N(
+    x?.price ?? x?.currentPrice ?? x?.amount ?? fallback?.basePrice,
+    0
+  );
+  return applyMarkup(base, x || fallback || {});
+}
+
+export async function quote({ items = [], coupon, method }) {
+  const lines = [];
+  for (const it of items) {
+    const qty = Math.max(1, N(it.qty, 1));
+    const unitPrice = await priceFor(String(it.id), it);
+    lines.push({
+      id: String(it.id),
+      name: it.name || it.title || "",
+      qty,
+      unitPrice,
+      lineTotal: +(unitPrice * qty).toFixed(2),
+    });
+  }
+  const subtotal = +lines
+    .reduce((s, l) => s + l.lineTotal, 0)
+    .toFixed(2);
+  const discount = 0; // TODO: coupons
+  const transaction = 0; // LiqPay commission not added to total
+  const total = +(subtotal - discount + transaction).toFixed(2);
+  return { lines, subtotal, discount, transaction, total };
+}


### PR DESCRIPTION
## Summary
- compute backend pricing with markup and expose quote API
- persist orders in Mongo and generate LiqPay checkout URLs
- show recalculated totals on payment page and disable pay button until valid

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0630785d4832b890b343fae0d996e