### PR TITLE
fix pricing fallback

### DIFF
--- a/utils/pricing.js
+++ b/utils/pricing.js
@@ -6,7 +6,7 @@ const N = (x, d = 0) => (Number.isFinite(+x) ? +x : d);
 async function priceFor(id, fallback) {
   const x = await fetchBambooById(id).catch(() => null);
   const base = N(
-    x?.price ?? x?.currentPrice ?? x?.amount ?? fallback?.basePrice,
+    x?.price ?? x?.currentPrice ?? x?.amount ?? fallback?.price ?? fallback?.basePrice,
     0
   );
   return applyMarkup(base, x || fallback || {});


### PR DESCRIPTION
## Summary
- include fallback item price in quote calculations so checkout totals are correct

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b072252214832b95383be97fc14119