### PR TITLE
fix checkout order summary

### DIFF
--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -118,9 +118,28 @@ export async function fetchBambooProducts(params) {
 export async function fetchBambooById(id) {
   try {
     const x = await bambooFetch(`/products/${encodeURIComponent(id)}`);
-    return x || null;
+    if (x && !Array.isArray(x) && !x.products && !x.items) return x;
+    const list = Array.isArray(x?.products)
+      ? x.products
+      : Array.isArray(x?.items)
+        ? x.items
+        : Array.isArray(x)
+          ? x
+          : [];
+    const found = list.find(
+      (p) =>
+        String(p.id) === String(id) ||
+        String(p.sku) === String(id) ||
+        String(p.code) === String(id)
+    );
+    if (found) return found;
   } catch (e) {
     console.warn("[bamboo] byId failed:", e?.message || e);
+  }
+  try {
+    const sample = loadSampleProducts();
+    return sample.find((p) => String(p.id) === String(id)) || null;
+  } catch {
     return null;
   }
 }

--- a/utils/pricing.js
+++ b/utils/pricing.js
@@ -1,20 +1,25 @@
 import { fetchBambooById } from "./bamboo.js";
 import { applyMarkup } from "./markup.js";
+import sample from "../data/sample-products.json" with { type: "json" };
 
 const N = (x, d = 0) => (Number.isFinite(+x) ? +x : d);
 
+const localIndex = new Map(sample.map((p) => [String(p.id), p]));
+
 async function priceFor(id, fallback) {
-  const x = await fetchBambooById(id).catch(() => null);
+  const remote = await fetchBambooById(id).catch(() => null);
+  const local = localIndex.get(String(id)) || null;
+  const product = remote || local || null;
   const base = N(
-    x?.price ??
-      x?.currentPrice ??
-      x?.amount ??
+    product?.price ??
+      product?.currentPrice ??
+      product?.amount ??
       fallback?.price ??
       fallback?.basePrice,
     0
   );
-  const price = applyMarkup(base, x || fallback || {});
-  return { product: x, price };
+  const price = applyMarkup(base, product || fallback || {});
+  return { product: product || fallback || null, price };
 }
 
 export async function quote({ items = [], coupon, method }) {


### PR DESCRIPTION
## Summary
- include fallback item price in quote calculations so checkout totals are correct
- look up product details when quoting to populate item names and prices
- fall back to local sample data if Bamboo API is unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "import('./utils/pricing.js').then(async m=>{console.log(await m.quote({items:[{id:'xbox-10-us',qty:2}]}) );})"`


------
https://chatgpt.com/codex/tasks/task_e_68b072252214832b95383be97fc14119