### PR TITLE
Add endpoint to group Bamboo catalog by category

### DIFF
--- a/routers/catalog.js
+++ b/routers/catalog.js
@@ -1,0 +1,51 @@
+import express from "express";
+import { fetchAllBambooProducts, mapProduct } from "../utils/bamboo.js";
+import { applyMarkup } from "../utils/markup.js";
+
+const router = express.Router();
+
+router.get("/", async (req, res) => {
+  try {
+    const { currency, lang } = req.query;
+    const raw = await fetchAllBambooProducts({ currency, lang });
+    const mapped = raw.map(mapProduct).map(p => {
+      const price = applyMarkup(p.price, p);
+      return {
+        ...p,
+        price,
+        oldPrice: p.price && price < p.price ? p.price : undefined,
+      };
+    });
+
+    const grouped = {};
+    for (const p of mapped) {
+      const cat = p.category || "other";
+      if (!grouped[cat]) {
+        grouped[cat] = {
+          products: [],
+          regions: new Set(),
+          denominations: new Set(),
+        };
+      }
+      grouped[cat].products.push(p);
+      if (p.region) grouped[cat].regions.add(p.region);
+      if (p.denomination) grouped[cat].denominations.add(p.denomination);
+    }
+
+    const result = {};
+    for (const [cat, g] of Object.entries(grouped)) {
+      result[cat] = {
+        products: g.products,
+        regions: Array.from(g.regions),
+        denominations: Array.from(g.denominations).sort((a, b) => a - b),
+      };
+    }
+
+    res.json(result);
+  } catch (e) {
+    console.error("[/api/catalog]", e?.message || e);
+    res.status(500).json({ error: true });
+  }
+});
+
+export default router;

--- a/server.mjs
+++ b/server.mjs
@@ -7,6 +7,7 @@ import cardsRouter from "./routers/cards.js";
 import searchRouter from "./routers/search.js";
 import checkoutRouter from "./routers/checkout.js";
 import liqpayRouter from "./routers/liqpay.js";
+import catalogRouter from "./routers/catalog.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -46,6 +47,7 @@ if (found) {
 
 app.use("/api/search", searchRouter);
 app.use("/api/cards", cardsRouter);
+app.use("/api/catalog", catalogRouter);
 app.use("/api/checkout", express.json(), checkoutRouter);
 app.use("/api/liqpay", liqpayRouter);
 

--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -115,6 +115,20 @@ export async function fetchBambooProducts(params) {
   }
 }
 
+export async function fetchAllBambooProducts(params = {}) {
+  const limit = safeN(params.limit, 100);
+  let page = 1;
+  const all = [];
+  while (true) {
+    const items = await fetchBambooProducts({ ...params, page: String(page), limit: String(limit) });
+    if (!items.length) break;
+    all.push(...items);
+    if (items.length < limit) break;
+    page += 1;
+  }
+  return all;
+}
+
 export async function fetchBambooById(id) {
   try {
     const x = await bambooFetch(`/products/${encodeURIComponent(id)}`);


### PR DESCRIPTION
## Summary
- fetch all Bamboo products and group them by main categories
- expose `/api/catalog` endpoint with region and denomination tags
- support collecting full catalog via new `fetchAllBambooProducts`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b07898422c832b9b6aa6eaf2411fee