### PR TITLE
Handle optional Bamboo API key in request headers

### DIFF
--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -54,12 +54,12 @@ export async function bambooFetch(path, params={}) {
   });
 
   try {
-    const res = await fetch(url, {
-      headers: {
-        "Accept": "application/json",
-        "Authorization": BAMBOO_KEY ? `Bearer ${BAMBOO_KEY}` : undefined,
-      }
-    });
+    const headers = {
+      "Accept": "application/json",
+    };
+    if (BAMBOO_KEY) headers["Authorization"] = `Bearer ${BAMBOO_KEY}`;
+
+    const res = await fetch(url, { headers });
     if (!res.ok) {
       const t = await res.text().catch(()=> "");
       throw new Error(`Bamboo ${res.status}: ${t || res.statusText}`);


### PR DESCRIPTION
## Summary
- Form headers in `bambooFetch` only adding `Authorization` when `BAMBOO_API_KEY` is set to avoid server rejections.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b07fe3a330832b99cc4fe6a7bbb409