### PR TITLE
Add diagnostic IP endpoint and Bamboo env normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "node": "18.x"
   },
   "scripts": {
-    "start": "node server.mjs"
+    "start": "node server.mjs",
+    "postbuild": "mkdir -p dist/data && cp -f src/data/sample-products.json dist/data/sample-products.json"
   },
   "dependencies": {
     "express": "^4.19.2",
-    "mongoose": "^7.6.3"
+    "mongoose": "^7.6.3",
+    "axios": "^1.6.7"
   }
 }

--- a/server.mjs
+++ b/server.mjs
@@ -8,6 +8,7 @@ import searchRouter from "./routers/search.js";
 import checkoutRouter from "./routers/checkout.js";
 import liqpayRouter from "./routers/liqpay.js";
 import catalogRouter from "./routers/catalog.js";
+import { diagRouter } from "./src/routes/diag.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -50,6 +51,8 @@ app.use("/api/cards", cardsRouter);
 app.use("/api/catalog", catalogRouter);
 app.use("/api/checkout", express.json(), checkoutRouter);
 app.use("/api/liqpay", liqpayRouter);
+app.use("/api/diag", diagRouter);
+app.use("/api/ip", diagRouter);
 
 app.get("/healthz", (_req, res) => res.status(200).send("OK"));
 

--- a/src/catalog/bambooClient.mjs
+++ b/src/catalog/bambooClient.mjs
@@ -1,0 +1,70 @@
+import axios from "axios";
+
+// ---- ENV NORMALIZATION ----
+const BASE =
+  process.env.BAMBOO_API_BASE ||
+  process.env.BAMBOO_API_URL ||
+  process.env.BAMBOO_BASE_URL ||
+  "";
+
+const CLIENT_ID =
+  process.env.BAMBOO_PROD_CLIENT_ID ||
+  process.env.BAMBOO_CLIENT_ID ||
+  "";
+
+const CLIENT_SECRET =
+  process.env.BAMBOO_PROD_CLIENT_SECRET ||
+  process.env.BAMBOO_CLIENT_SECRET ||
+  "";
+
+// шлях каталогу можна перевизначати через ENV
+const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || "/catalog").replace(/\/+$/, "") || "/catalog";
+
+if (!BASE) console.error("[bamboo] BASE url is EMPTY. Set BAMBOO_API_URL or BAMBOO_BASE_URL in Render.");
+if (!CLIENT_ID || !CLIENT_SECRET) console.warn("[bamboo] CLIENT_ID/CLIENT_SECRET missing — check Render ENV.");
+
+export const api = axios.create({
+  baseURL: BASE.replace(/\/+$/, ""), // без кінцевого слеша
+  timeout: 15000,
+  headers: {
+    "Content-Type": "application/json",
+    // Якщо у вашій інтеграції інша схема (Bearer), замініть тут відповідно.
+    "X-Client-Id": CLIENT_ID,
+    "X-Client-Secret": CLIENT_SECRET,
+  },
+});
+
+export async function* paginateCatalog(params = {}) {
+  let next = null;
+  let page = 1;
+
+  while (true) {
+    const query = { ...params };
+    if ("cursor" in (next || {})) query.cursor = next.cursor;
+    else query.page = page;
+
+    try {
+      const { data } = await api.get(CATALOG_PATH, { params: query });
+      const items = data?.items || data?.data || [];
+      if (!items.length) break;
+
+      yield items;
+
+      next = data?.next || data?.pagination?.next || null;
+      if (!next && !data?.pagination) {
+        if (items.length < (params.limit || 100)) break;
+        page += 1;
+      } else if (!next) break;
+    } catch (e) {
+      const st = e?.response?.status;
+      const body = e?.response?.data;
+      console.error(
+        "[bamboo] fetch error:",
+        st || e?.code || e?.message,
+        body && typeof body === "object" ? JSON.stringify(body).slice(0, 400) : body || ""
+      );
+      throw e;
+    }
+  }
+}
+

--- a/src/data/sample-products.json
+++ b/src/data/sample-products.json
@@ -1,0 +1,218 @@
+[
+  {
+    "id": "xbox-10-us",
+    "name": "Xbox Gift Card $10 (US)",
+    "platform": "XBOX",
+    "region": "US",
+    "denomination": 10,
+    "price": 10,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-25-us",
+    "name": "Xbox Gift Card $25 (US)",
+    "platform": "XBOX",
+    "region": "US",
+    "denomination": 25,
+    "price": 25,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-15-eu",
+    "name": "Xbox Gift Card €15 (EU)",
+    "platform": "XBOX",
+    "region": "EU",
+    "denomination": 15,
+    "price": 15,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-50-eu",
+    "name": "Xbox Gift Card €50 (EU)",
+    "platform": "XBOX",
+    "region": "EU",
+    "denomination": 50,
+    "price": 50,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-20-ua",
+    "name": "Xbox Gift Card ₴20 (UA)",
+    "platform": "XBOX",
+    "region": "UA",
+    "denomination": 20,
+    "price": 20,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-100-ua",
+    "name": "Xbox Gift Card ₴100 (UA)",
+    "platform": "XBOX",
+    "region": "UA",
+    "denomination": 100,
+    "price": 100,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-15-pl",
+    "name": "Xbox Gift Card zł15 (PL)",
+    "platform": "XBOX",
+    "region": "PL",
+    "denomination": 15,
+    "price": 15,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "xbox-50-pl",
+    "name": "Xbox Gift Card zł50 (PL)",
+    "platform": "XBOX",
+    "region": "PL",
+    "denomination": 50,
+    "price": 50,
+    "img": "https://via.placeholder.com/300x180?text=XBOX"
+  },
+  {
+    "id": "playstation-10-us",
+    "name": "PlayStation Gift Card $10 (US)",
+    "platform": "PLAYSTATION",
+    "region": "US",
+    "denomination": 10,
+    "price": 10,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-25-us",
+    "name": "PlayStation Gift Card $25 (US)",
+    "platform": "PLAYSTATION",
+    "region": "US",
+    "denomination": 25,
+    "price": 25,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-15-eu",
+    "name": "PlayStation Gift Card €15 (EU)",
+    "platform": "PLAYSTATION",
+    "region": "EU",
+    "denomination": 15,
+    "price": 15,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-50-eu",
+    "name": "PlayStation Gift Card €50 (EU)",
+    "platform": "PLAYSTATION",
+    "region": "EU",
+    "denomination": 50,
+    "price": 50,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-20-ua",
+    "name": "PlayStation Gift Card ₴20 (UA)",
+    "platform": "PLAYSTATION",
+    "region": "UA",
+    "denomination": 20,
+    "price": 20,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-100-ua",
+    "name": "PlayStation Gift Card ₴100 (UA)",
+    "platform": "PLAYSTATION",
+    "region": "UA",
+    "denomination": 100,
+    "price": 100,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-15-pl",
+    "name": "PlayStation Gift Card zł15 (PL)",
+    "platform": "PLAYSTATION",
+    "region": "PL",
+    "denomination": 15,
+    "price": 15,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "playstation-50-pl",
+    "name": "PlayStation Gift Card zł50 (PL)",
+    "platform": "PLAYSTATION",
+    "region": "PL",
+    "denomination": 50,
+    "price": 50,
+    "img": "https://via.placeholder.com/300x180?text=PS"
+  },
+  {
+    "id": "steam-10-us",
+    "name": "Steam Gift Card $10 (US)",
+    "platform": "STEAM",
+    "region": "US",
+    "denomination": 10,
+    "price": 10,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-25-us",
+    "name": "Steam Gift Card $25 (US)",
+    "platform": "STEAM",
+    "region": "US",
+    "denomination": 25,
+    "price": 25,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-15-eu",
+    "name": "Steam Gift Card €15 (EU)",
+    "platform": "STEAM",
+    "region": "EU",
+    "denomination": 15,
+    "price": 15,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-50-eu",
+    "name": "Steam Gift Card €50 (EU)",
+    "platform": "STEAM",
+    "region": "EU",
+    "denomination": 50,
+    "price": 50,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-20-ua",
+    "name": "Steam Gift Card ₴20 (UA)",
+    "platform": "STEAM",
+    "region": "UA",
+    "denomination": 20,
+    "price": 20,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-100-ua",
+    "name": "Steam Gift Card ₴100 (UA)",
+    "platform": "STEAM",
+    "region": "UA",
+    "denomination": 100,
+    "price": 100,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-15-pl",
+    "name": "Steam Gift Card zł15 (PL)",
+    "platform": "STEAM",
+    "region": "PL",
+    "denomination": 15,
+    "price": 15,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  },
+  {
+    "id": "steam-50-pl",
+    "name": "Steam Gift Card zł50 (PL)",
+    "platform": "STEAM",
+    "region": "PL",
+    "denomination": 50,
+    "price": 50,
+    "img": "https://via.placeholder.com/300x180?text=STEAM"
+  }
+]

--- a/src/routes/diag.mjs
+++ b/src/routes/diag.mjs
@@ -1,0 +1,27 @@
+import express from "express";
+import axios from "axios";
+
+export const diagRouter = express.Router();
+
+// основний ендпоїнт
+diagRouter.get("/egress-ip", async (req, res) => {
+  try {
+    const { data } = await axios.get("https://api.ipify.org?format=json", { timeout: 5000 });
+    return res.json({ ip: data?.ip || null });
+  } catch (e) {
+    console.error("[diag] egress-ip error:", e?.code || e?.message);
+    return res.status(500).json({ ip: null, error: e?.message || "failed" });
+  }
+});
+
+// короткий синонім
+diagRouter.get("/", async (req, res) => {
+  try {
+    const { data } = await axios.get("https://api.ipify.org?format=json", { timeout: 5000 });
+    return res.json({ ip: data?.ip || null });
+  } catch (e) {
+    console.error("[diag] ip error:", e?.code || e?.message);
+    return res.status(500).json({ ip: null, error: e?.message || "failed" });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add /api/diag/egress-ip endpoint with short /api/ip alias
- normalize Bamboo env variables and improve logging
- copy sample-products.json into build output via postbuild script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run postbuild`


------
https://chatgpt.com/codex/tasks/task_e_68b1a56ed52c832b94d3b75cb5aace26