### PR TITLE
feat: add bamboo diagnostic route

### DIFF
--- a/src/catalog/bambooClient.mjs
+++ b/src/catalog/bambooClient.mjs
@@ -1,43 +1,51 @@
 import axios from "axios";
 
-// ---- ENV NORMALIZATION ----
 const BASE =
   process.env.BAMBOO_API_BASE ||
   process.env.BAMBOO_API_URL ||
   process.env.BAMBOO_BASE_URL ||
   "";
 
+const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || "/catalog").replace(/\/+$/, "") || "/catalog";
+
+// authMode: "BEARER" або "HEADERS" (за замовчуванням HEADERS, якщо немає токена)
+const AUTH_MODE = (process.env.BAMBOO_AUTH_MODE || (process.env.BAMBOO_API_TOKEN ? "BEARER" : "HEADERS")).toUpperCase();
+
 const CLIENT_ID =
   process.env.BAMBOO_PROD_CLIENT_ID ||
-  process.env.BAMBOO_CLIENT_ID ||
-  "";
+  process.env.BAMBOO_CLIENT_ID || "";
 
 const CLIENT_SECRET =
   process.env.BAMBOO_PROD_CLIENT_SECRET ||
-  process.env.BAMBOO_CLIENT_SECRET ||
-  "";
+  process.env.BAMBOO_CLIENT_SECRET || "";
 
-// шлях каталогу можна перевизначати через ENV
-const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || "/catalog").replace(/\/+$/, "") || "/catalog";
+const TOKEN = process.env.BAMBOO_API_TOKEN || "";
 
-if (!BASE) console.error("[bamboo] BASE url is EMPTY. Set BAMBOO_API_URL or BAMBOO_BASE_URL in Render.");
-if (!CLIENT_ID || !CLIENT_SECRET) console.warn("[bamboo] CLIENT_ID/CLIENT_SECRET missing — check Render ENV.");
+if (!BASE) console.error("[bamboo] BASE url is EMPTY. Set BAMBOO_API_URL/BAMBOO_BASE_URL.");
+if (AUTH_MODE === "HEADERS" && (!CLIENT_ID || !CLIENT_SECRET)) {
+  console.warn("[bamboo] CLIENT_ID/CLIENT_SECRET missing — check ENV.");
+}
+if (AUTH_MODE === "BEARER" && !TOKEN) {
+  console.warn("[bamboo] BAMBOO_API_TOKEN is empty — check ENV.");
+}
+
+const headers = { "Content-Type": "application/json" };
+if (AUTH_MODE === "BEARER") {
+  headers.Authorization = `Bearer ${TOKEN}`;
+} else {
+  headers["X-Client-Id"] = CLIENT_ID;
+  headers["X-Client-Secret"] = CLIENT_SECRET;
+}
 
 export const api = axios.create({
-  baseURL: BASE.replace(/\/+$/, ""), // без кінцевого слеша
+  baseURL: BASE.replace(/\/+$/, ""),
   timeout: 15000,
-  headers: {
-    "Content-Type": "application/json",
-    // Якщо у вашій інтеграції інша схема (Bearer), замініть тут відповідно.
-    "X-Client-Id": CLIENT_ID,
-    "X-Client-Secret": CLIENT_SECRET,
-  },
+  headers,
 });
 
 export async function* paginateCatalog(params = {}) {
   let next = null;
   let page = 1;
-
   while (true) {
     const query = { ...params };
     if ("cursor" in (next || {})) query.cursor = next.cursor;
@@ -45,9 +53,8 @@ export async function* paginateCatalog(params = {}) {
 
     try {
       const { data } = await api.get(CATALOG_PATH, { params: query });
-      const items = data?.items || data?.data || [];
-      if (!items.length) break;
-
+      const items = data?.items || data?.data || data || [];
+      if (!Array.isArray(items) || !items.length) break;
       yield items;
 
       next = data?.next || data?.pagination?.next || null;
@@ -58,13 +65,33 @@ export async function* paginateCatalog(params = {}) {
     } catch (e) {
       const st = e?.response?.status;
       const body = e?.response?.data;
-      console.error(
-        "[bamboo] fetch error:",
+      console.error("[bamboo] fetch error:",
         st || e?.code || e?.message,
         body && typeof body === "object" ? JSON.stringify(body).slice(0, 400) : body || ""
       );
       throw e;
     }
   }
+}
+
+// утилітка для діагностики IP
+export async function getEgressIp() {
+  try {
+    const { data } = await axios.get("https://api.ipify.org?format=json", { timeout: 5000 });
+    return data?.ip || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getBambooConfig() {
+  return {
+    baseUrl: BASE,
+    catalogPath: CATALOG_PATH,
+    authMode: AUTH_MODE,
+    hasClientId: Boolean(CLIENT_ID),
+    hasClientSecret: Boolean(CLIENT_SECRET),
+    hasToken: Boolean(TOKEN),
+  };
 }
 

--- a/src/routes/diag.mjs
+++ b/src/routes/diag.mjs
@@ -1,24 +1,59 @@
 import express from "express";
-import axios from "axios";
+import { api, getEgressIp, getBambooConfig } from "../catalog/bambooClient.mjs";
 
 export const diagRouter = express.Router();
 
-// основний ендпоїнт
+diagRouter.get("/bamboo", async (req, res) => {
+  const cfg = getBambooConfig();
+  const ip = await getEgressIp();
+
+  try {
+    const { data, status } = await api.get(cfg.catalogPath, { params: { limit: 5 } });
+    const items = Array.isArray(data?.items) ? data.items :
+                  Array.isArray(data?.data) ? data.data :
+                  Array.isArray(data) ? data : [];
+    const preview = items.slice(0, 5).map(it => ({
+      id: it.id ?? it.productId ?? it.sku ?? null,
+      name: it.name ?? it.title ?? it.displayName ?? null,
+    }));
+
+    return res.json({
+      ok: true,
+      status,
+      egressIp: ip,
+      config: cfg,
+      count: items.length || 0,
+      preview,
+    });
+  } catch (e) {
+    const status = e?.response?.status || null;
+    const body = e?.response?.data || e?.message || "error";
+    return res.status(200).json({
+      ok: false,
+      status,
+      egressIp: ip,
+      config: cfg,
+      error: typeof body === "object" ? body : String(body),
+    });
+  }
+});
+
 diagRouter.get("/egress-ip", async (req, res) => {
   try {
-    const { data } = await axios.get("https://api.ipify.org?format=json", { timeout: 5000 });
-    return res.json({ ip: data?.ip || null });
+    const ip = await getEgressIp();
+    if (!ip) throw new Error("failed to fetch ip");
+    return res.json({ ip });
   } catch (e) {
     console.error("[diag] egress-ip error:", e?.code || e?.message);
     return res.status(500).json({ ip: null, error: e?.message || "failed" });
   }
 });
 
-// короткий синонім
 diagRouter.get("/", async (req, res) => {
   try {
-    const { data } = await axios.get("https://api.ipify.org?format=json", { timeout: 5000 });
-    return res.json({ ip: data?.ip || null });
+    const ip = await getEgressIp();
+    if (!ip) throw new Error("failed to fetch ip");
+    return res.json({ ip });
   } catch (e) {
     console.error("[diag] ip error:", e?.code || e?.message);
     return res.status(500).json({ ip: null, error: e?.message || "failed" });


### PR DESCRIPTION
## Summary
- improve Bamboo client to support BEARER and header auth modes and expose diagnostics helpers
- add `/api/diag/bamboo` route returning connection status and sample products
- keep IP diagnostic endpoints using shared helper

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab1b18e0832b913e98e67b4e4b58