### PR TITLE
feat: add OAuth client credential auth for Bamboo

### DIFF
--- a/src/catalog/auth.mjs
+++ b/src/catalog/auth.mjs
@@ -1,0 +1,72 @@
+import axios from "axios";
+
+// ENV
+const AUTH_MODE = (process.env.BAMBOO_AUTH_MODE || "OAUTH").toUpperCase(); // OAUTH | SECRET | BEARER | HEADERS
+const CLIENT_ID = process.env.BAMBOO_PROD_CLIENT_ID || process.env.BAMBOO_CLIENT_ID || "";
+const CLIENT_SECRET = process.env.BAMBOO_PROD_CLIENT_SECRET || process.env.BAMBOO_CLIENT_SECRET || "";
+const SECRET_KEY = process.env.BAMBOO_SECRET_KEY || ""; // для SECRET-режиму
+const API_TOKEN = process.env.BAMBOO_API_TOKEN || "";   // для BEARER-режиму
+
+// Токен-ендпоінт можна задати повністю або як BASE+PATH
+const BASE =
+  process.env.BAMBOO_API_BASE ||
+  process.env.BAMBOO_API_URL ||
+  process.env.BAMBOO_BASE_URL ||
+  "https://api.bamboocardportal.com";
+const TOKEN_URL =
+  process.env.BAMBOO_TOKEN_URL ||
+  `${BASE.replace(/\/+$/, "")}${process.env.BAMBOO_TOKEN_PATH || "/connect/token"}`;
+
+let cached = { token: null, exp: 0 };
+
+async function fetchToken() {
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
+  const { data } = await axios.post(TOKEN_URL, body.toString(), {
+    timeout: 15000,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  if (!data?.access_token) throw new Error("No access_token in token response");
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = Number(data.expires_in || 3600);
+  cached = { token: data.access_token, exp: now + Math.max(300, ttl - 60) }; // мін. 5 хв, -60s запас
+  return cached.token;
+}
+
+async function getBearer() {
+  const now = Math.floor(Date.now() / 1000);
+  if (cached.token && cached.exp > now) return cached.token;
+  return fetchToken();
+}
+
+export async function authHeaders() {
+  switch (AUTH_MODE) {
+    case "OAUTH": {
+      const token = await getBearer();
+      return { Authorization: `Bearer ${token}` };
+    }
+    case "SECRET":
+      return { "X-Client-Id": CLIENT_ID, "X-Secret-Key": SECRET_KEY };
+    case "BEARER":
+      return { Authorization: `Bearer ${API_TOKEN}` };
+    case "HEADERS":
+      return { "X-Client-Id": CLIENT_ID, "X-Client-Secret": CLIENT_SECRET };
+    default:
+      return {};
+  }
+}
+
+export function debugAuthConfig() {
+  return {
+    mode: AUTH_MODE,
+    hasClientId: Boolean(CLIENT_ID),
+    hasClientSecret: Boolean(CLIENT_SECRET),
+    hasSecretKey: Boolean(SECRET_KEY),
+    hasApiToken: Boolean(API_TOKEN),
+    tokenUrl: TOKEN_URL,
+  };
+}
+

--- a/src/catalog/bambooClient.mjs
+++ b/src/catalog/bambooClient.mjs
@@ -1,58 +1,18 @@
 import axios from "axios";
+import { authHeaders, debugAuthConfig } from "./auth.mjs";
 
-// ---- base + paths ----
 const BASE =
   process.env.BAMBOO_API_BASE ||
   process.env.BAMBOO_API_URL ||
   process.env.BAMBOO_BASE_URL ||
-  "";
-// дозволяємо перевизначати шлях каталогу з ENV (за замовчуванням /catalog)
-const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || "/catalog").replace(/\/+$/, "") || "/catalog";
-
-// ---- auth modes ----
-// Підтримувані режими:
-//  - BEARER : Authorization: Bearer <token> (BAMBOO_API_TOKEN)
-//  - SECRET : X-Secret-Key: <key> (BAMBOO_SECRET_KEY)
-//  - HEADERS: X-Client-Id / X-Client-Secret (BAMBOO_CLIENT_ID / BAMBOO_CLIENT_SECRET)
-const AUTH_MODE = (process.env.BAMBOO_AUTH_MODE ||
-  (process.env.BAMBOO_API_TOKEN ? "BEARER" : (process.env.BAMBOO_SECRET_KEY ? "SECRET" : "HEADERS"))
-).toUpperCase();
-
-const CLIENT_ID = process.env.BAMBOO_PROD_CLIENT_ID || process.env.BAMBOO_CLIENT_ID || "";
-const CLIENT_SECRET = process.env.BAMBOO_PROD_CLIENT_SECRET || process.env.BAMBOO_CLIENT_SECRET || "";
-const TOKEN = process.env.BAMBOO_API_TOKEN || "";
-const SECRET_KEY = process.env.BAMBOO_SECRET_KEY || "";
-
-if (!BASE) console.error("[bamboo] BASE url is EMPTY. Set BAMBOO_API_URL/BAMBOO_BASE_URL.");
-if (AUTH_MODE === "HEADERS" && (!CLIENT_ID || !CLIENT_SECRET)) {
-  console.warn("[bamboo] CLIENT_ID/CLIENT_SECRET missing — check ENV.");
-}
-if (AUTH_MODE === "BEARER" && !TOKEN) {
-  console.warn("[bamboo] BAMBOO_API_TOKEN is empty — check ENV.");
-}
-if (AUTH_MODE === "SECRET" && !SECRET_KEY) {
-  console.warn("[bamboo] BAMBOO_SECRET_KEY is empty — check ENV.");
-}
-
-const headers = { "Content-Type": "application/json" };
-switch (AUTH_MODE) {
-  case "BEARER":
-    headers.Authorization = `Bearer ${TOKEN}`;
-    break;
-  case "SECRET":
-    headers["X-Secret-Key"] = SECRET_KEY;
-    // деякі інсталяції також вимагають Client-Id поряд із Secret — залишимо умовно:
-    if (CLIENT_ID) headers["X-Client-Id"] = CLIENT_ID;
-    break;
-  default: // HEADERS
-    headers["X-Client-Id"] = CLIENT_ID;
-    headers["X-Client-Secret"] = CLIENT_SECRET;
-}
+  "https://api.bamboocardportal.com";
+// за замовчуванням — v2.0
+const DEFAULT_CATALOG = "/api/integration/v2.0/catalog";
+const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || DEFAULT_CATALOG).replace(/\/+$/, "") || DEFAULT_CATALOG;
 
 export const api = axios.create({
   baseURL: BASE.replace(/\/+$/, ""),
   timeout: 15000,
-  headers,
 });
 
 export async function* paginateCatalog(params = {}) {
@@ -62,9 +22,9 @@ export async function* paginateCatalog(params = {}) {
     const query = { ...params };
     if ("cursor" in (next || {})) query.cursor = next.cursor;
     else query.page = page;
-
     try {
-      const { data } = await api.get(CATALOG_PATH, { params: query });
+      const headers = { "Content-Type": "application/json", ...(await authHeaders()) };
+      const { data } = await api.get(CATALOG_PATH, { params: query, headers });
       const items = data?.items || data?.data || data || [];
       if (!Array.isArray(items) || !items.length) break;
       yield items;
@@ -86,7 +46,6 @@ export async function* paginateCatalog(params = {}) {
   }
 }
 
-// утилітка для діагностики IP
 export async function getEgressIp() {
   try {
     const { data } = await axios.get("https://api.ipify.org?format=json", { timeout: 5000 });
@@ -100,11 +59,7 @@ export function getBambooConfig() {
   return {
     baseUrl: BASE,
     catalogPath: CATALOG_PATH,
-    authMode: AUTH_MODE,
-    hasClientId: Boolean(CLIENT_ID),
-    hasClientSecret: Boolean(CLIENT_SECRET),
-    hasToken: Boolean(TOKEN),
-    hasSecretKey: Boolean(SECRET_KEY),
+    ...debugAuthConfig(),
   };
 }
 


### PR DESCRIPTION
## Summary
- add OAuth2 client credentials support with token caching
- switch Bamboo catalog to v2.0 and centralize auth
- expose auth config in diagnostics

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check src/catalog/auth.mjs`
- `node --check src/catalog/bambooClient.mjs`
- `node --check src/routes/diag.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b2a08d49e8832b9c10bd2240ad3d38