### PR TITLE
Improve OAuth token retrieval and diagnostics

### DIFF
--- a/src/routes/diag.mjs
+++ b/src/routes/diag.mjs
@@ -28,9 +28,8 @@ diagRouter.get("/bamboo", async (_req, res) => {
     "https://api.bamboocardportal.com";
   const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || "/api/integration/v2.0/catalog").replace(/\/+$/, "") || "/api/integration/v2.0/catalog";
 
-  const headers = { "Content-Type": "application/json" };
-  Object.assign(headers, await authHeaders());
-  const headerKeys = Object.keys(headers);
+    const headers = { "Content-Type": "application/json", ...(await authHeaders()) };
+    const headerKeys = Object.keys(headers);
 
   let ip = null;
   try {


### PR DESCRIPTION
## Summary
- add masked logging for selected Bamboo client ID
- enhance OAuth token fetch with Basic auth fallback and detailed logging
- streamline diag route headers merging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2a86b8b20832bbf1d98ea8ae8ce66