### PR TITLE
feat: improve auth diagnostics and scope support

### DIFF
--- a/src/routes/diag.mjs
+++ b/src/routes/diag.mjs
@@ -28,7 +28,13 @@ diagRouter.get("/bamboo", async (_req, res) => {
     "https://api.bamboocardportal.com";
   const CATALOG_PATH = (process.env.BAMBOO_CATALOG_PATH || "/api/integration/v2.0/catalog").replace(/\/+$/, "") || "/api/integration/v2.0/catalog";
 
-    const headers = { "Content-Type": "application/json", ...(await authHeaders()) };
+    const headers = { "Content-Type": "application/json" };
+    let authErr = null;
+    try {
+      Object.assign(headers, await authHeaders());
+    } catch (e) {
+      authErr = e?.response?.data || e?.message || "authHeaders failed";
+    }
     const headerKeys = Object.keys(headers);
 
   let ip = null;
@@ -74,7 +80,7 @@ diagRouter.get("/bamboo", async (_req, res) => {
       status,
       egressIp: ip,
       config: { baseUrl: BASE, catalogPath: CATALOG_PATH, ...debugAuthConfig() },
-      error: typeof body === "object" ? body : String(body)
+      error: authErr ? { auth: authErr } : (typeof body === "object" ? body : String(body))
     });
   }
 });


### PR DESCRIPTION
## Summary
- add OAuth scope env and flexible token URL usage
- harden authHeaders with logging and error catch
- avoid diag crash when auth fails and surface auth error

## Testing
- `node --check src/catalog/auth.mjs`
- `node --check src/routes/diag.mjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2aa781108832ba0ecc8b92a819ebb