### PR TITLE
feat: try multiple Bamboo secret auth headers

### DIFF
--- a/src/catalog/auth.mjs
+++ b/src/catalog/auth.mjs
@@ -112,3 +112,31 @@ export function debugAuthConfig() {
   };
 }
 
+// Варіанти заголовків для SECRET-режиму
+export function secretHeaderVariants() {
+  // ENV-перемикач на випадок, якщо потрібно примусово задати ім'я ключа
+  const KEY_HEADER = process.env.BAMBOO_KEY_HEADER?.trim(); // напр. "X-Api-Key" або "X-Secret-Key"
+  const arr = [];
+  if (KEY_HEADER) {
+    const h = {};
+    h[KEY_HEADER] = SECRET_KEY;
+    if (CLIENT_ID) h["X-Client-Id"] = CLIENT_ID;
+    arr.push(h);
+  }
+  // Стандартні спроби (найчастіші зверху)
+  arr.push(
+    // 1) X-Api-Key (без Client-Id)
+    { "X-Api-Key": SECRET_KEY },
+    // 2) X-Api-Key + X-Client-Id
+    { "X-Api-Key": SECRET_KEY, "X-Client-Id": CLIENT_ID },
+    // 3) X-Secret-Key + X-Client-Id
+    { "X-Secret-Key": SECRET_KEY, "X-Client-Id": CLIENT_ID }
+  );
+  // Прибери пусті Client-Id, якщо його немає
+  return arr.map(h => {
+    const copy = { ...h };
+    if (!CLIENT_ID) delete copy["X-Client-Id"];
+    return copy;
+  });
+}
+


### PR DESCRIPTION
## Summary
- add generator for Bamboo secret auth header variants
- retry Bamboo catalog requests with different secret headers and expose which one succeeds
- surface used header names in diagnostic endpoint

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check src/catalog/auth.mjs src/catalog/bambooClient.mjs src/routes/diag.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b2ac4d3a4c832b962e3110161e2f60