### PR TITLE
feat: add catalog cache service and routes

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,12 @@ services:
     envVars:
       - key: VITE_API_BASE
         value: https://digi-backend-ln8f.onrender.com/api
+      - key: CATALOG_CACHE_TTL_MIN
+        value: "60"
+      - key: CATALOG_CACHE_PATH
+        value: ./data/catalog-cache.json
+      - key: CATALOG_MAX_ITEMS
+        value: "10000"
     buildCommand: >
       npm --prefix frontend install --no-audit --no-fund --registry=https://registry.npmjs.org
       && npm --prefix frontend run build

--- a/src/catalog/catalogService.mjs
+++ b/src/catalog/catalogService.mjs
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { paginateCatalog, getBambooConfig } from "./bambooClient.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const CACHE_PATH = process.env.CATALOG_CACHE_PATH || path.join(__dirname, "..", "data", "catalog-cache.json");
+const TTL_MIN = Math.max(1, Number(process.env.CATALOG_CACHE_TTL_MIN || 60));
+const MAX_ITEMS = Math.max(100, Number(process.env.CATALOG_MAX_ITEMS || 10000));
+
+let inFlight = null; // проміс, що сигналізує активне оновлення, щоб не дублювати запити
+
+async function ensureDirExists(p) {
+  try {
+    await fs.mkdir(path.dirname(p), { recursive: true });
+  } catch {}
+}
+
+async function readCache() {
+  try {
+    const raw = await fs.readFile(CACHE_PATH, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return {
+      updatedAt: 0,
+      source: "none",
+      items: [],
+      meta: { lastError: null, lastErrorAt: 0, ttlMin: TTL_MIN, maxItems: MAX_ITEMS },
+      bamboo: getBambooConfig(),
+    };
+  }
+}
+
+async function writeCache(doc) {
+  await ensureDirExists(CACHE_PATH);
+  const payload = JSON.stringify(doc, null, 2);
+  await fs.writeFile(CACHE_PATH, payload, "utf8");
+}
+
+function isFresh(cache) {
+  const ageMin = (Date.now() - (cache.updatedAt || 0)) / 60000;
+  return ageMin < TTL_MIN && (cache.items?.length || 0) > 0;
+}
+
+async function fetchAllFromBamboo() {
+  const items = [];
+  for await (const page of paginateCatalog({ limit: 200 })) {
+    for (const it of page) {
+      items.push(it);
+      if (items.length >= MAX_ITEMS) break;
+    }
+    if (items.length >= MAX_ITEMS) break;
+  }
+  return items;
+}
+
+/**
+ * Оновлює кеш із Bamboo. Якщо помилка — не ламає кеш, просто записує lastError.
+ * @param {object} opts
+ * @param {boolean} opts.force - ігнорувати TTL
+ * @returns {Promise<{items, source, updatedAt, meta, bamboo}>}
+ */
+export async function refreshCatalog({ force = false } = {}) {
+  const cache = await readCache();
+  if (!force && isFresh(cache)) {
+    return { ...cache, source: "cache" };
+  }
+
+  // Лок — щоб не запускати паралельно
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const items = await fetchAllFromBamboo();
+      const doc = {
+        updatedAt: Date.now(),
+        source: "bamboo",
+        items,
+        meta: { lastError: null, lastErrorAt: 0, ttlMin: TTL_MIN, maxItems: MAX_ITEMS, count: items.length },
+        bamboo: getBambooConfig(),
+      };
+      await writeCache(doc);
+      return doc;
+    } catch (e) {
+      const doc = {
+        ...cache,
+        source: "cache",
+        meta: {
+          ...(cache.meta || {}),
+          lastError: e?.response?.data || e?.message || String(e),
+          lastErrorAt: Date.now(),
+          ttlMin: TTL_MIN,
+          maxItems: MAX_ITEMS,
+          count: cache.items?.length || 0,
+        },
+        bamboo: getBambooConfig(),
+      };
+      // зберігаємо оновлену мету, але не перетираємо items, якщо упало
+      await writeCache(doc);
+      return doc;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+/**
+ * Повертає дані каталогу без примусового оновлення.
+ * Якщо кеш протух — спробує тихо оновити, але все одно поверне те, що є.
+ */
+export async function getCatalog() {
+  const cache = await readCache();
+  if (isFresh(cache)) {
+    return { ...cache, source: "cache" };
+  }
+  // Без очікування (не блокуємо відповідь) запускаємо оновлення у фоні
+  refreshCatalog({ force: false }).catch(() => {});
+  // Віддаємо поточний кеш (якщо пустий — все одно віддаємо, але з метою)
+  return { ...cache, source: (cache.items?.length ? "cache" : "none") };
+}
+
+/** Метадані кешу без віддачі всіх items */
+export async function getCatalogStatus() {
+  const cache = await readCache();
+  const ageMin = ((Date.now() - (cache.updatedAt || 0)) / 60000).toFixed(1);
+  return {
+    updatedAt: cache.updatedAt,
+    ageMin: Number(ageMin),
+    count: cache.items?.length || 0,
+    meta: cache.meta || {},
+    bamboo: cache.bamboo || getBambooConfig(),
+    inFlight: Boolean(inFlight),
+    ttlMin: TTL_MIN,
+    cachePath: CACHE_PATH,
+    maxItems: MAX_ITEMS,
+  };
+}
+

--- a/src/routes/catalog.mjs
+++ b/src/routes/catalog.mjs
@@ -1,0 +1,53 @@
+import express from "express";
+import { getCatalog, refreshCatalog, getCatalogStatus } from "../catalog/catalogService.mjs";
+
+export const catalogRouter = express.Router();
+
+// Віддати каталог (кеш/свіжі)
+catalogRouter.get("/catalog", async (req, res) => {
+  try {
+    const doc = await getCatalog();
+    const notice = doc.source !== "bamboo" ? "Serving cached catalog (Bamboo limited to hourly updates)." : null;
+    res.json({
+      ok: true,
+      source: doc.source,
+      updatedAt: doc.updatedAt,
+      count: doc.items?.length || 0,
+      notice,
+      items: doc.items || [],
+    });
+  } catch (e) {
+    res.status(200).json({
+      ok: false,
+      error: e?.message || "failed",
+    });
+  }
+});
+
+// Примусовий рефреш (діагностика/адмін). За замовчуванням шанує TTL; з ?force=1 ігнорує.
+catalogRouter.post("/diag/bamboo/refresh", async (req, res) => {
+  try {
+    const force = String(req.query.force || "") === "1";
+    const doc = await refreshCatalog({ force });
+    res.json({
+      ok: true,
+      source: doc.source,
+      updatedAt: doc.updatedAt,
+      count: doc.items?.length || 0,
+      meta: doc.meta,
+    });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "refresh failed" });
+  }
+});
+
+// Статус кешу (без items)
+catalogRouter.get("/diag/bamboo/status", async (_req, res) => {
+  try {
+    const st = await getCatalogStatus();
+    res.json({ ok: true, ...st });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "status failed" });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add catalog service with JSON cache and TTL
- expose /api/catalog plus Bamboo diagnostic endpoints
- refresh cache on startup and configure env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.mjs` *(fails: [bamboo] fetch error: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cdc2bd14832bba3976f6539cbf9c