### PR TITLE
Improve MongoDB connection handling

### DIFF
--- a/src/utils/db.mjs
+++ b/src/utils/db.mjs
@@ -1,21 +1,48 @@
 import mongoose from "mongoose";
 
-const uri =
+function maskUri(u = "") {
+  // ховаємо пароль у логах
+  try {
+    const url = new URL(u);
+    if (url.password) url.password = "***";
+    return url.toString();
+  } catch {
+    return u ? u.slice(0, 20) + "..." : "";
+  }
+}
+
+const URI =
   process.env.MONGODB_URI ||
   process.env.DB_URL ||
   "";
 
+const DB_NAME = process.env.MONGODB_DB_NAME || ""; // якщо в URI немає /dbname — можна задати тут
+
 export async function connectMongo() {
-  if (!uri) {
+  if (!URI) {
     console.warn("⚠️  No Mongo URI provided (checked MONGODB_URI and DB_URL). Skipping DB connection.");
     return;
   }
+
+  const opts = {
+    serverSelectionTimeoutMS: 10000,
+    maxPoolSize: 10,
+    // якщо явно передали MONGODB_DB_NAME — використаємо
+    ...(DB_NAME ? { dbName: DB_NAME } : {}),
+  };
+
+  console.log("ℹ️  Mongo connecting to:", maskUri(URI), DB_NAME ? `(dbName=${DB_NAME})` : "");
+
   try {
-    await mongoose.connect(uri, {
-      serverSelectionTimeoutMS: 10000,
-      maxPoolSize: 10,
-    });
-    console.log("✅ Mongo connected:", mongoose.connection.name);
+    const conn = await mongoose.connect(URI, opts);
+    // обережно читаємо назву БД — без падінь
+    const name =
+      conn?.connection?.name ||
+      conn?.connection?.db?.databaseName ||
+      mongoose?.connection?.name ||
+      mongoose?.connection?.db?.databaseName ||
+      "(unknown)";
+    console.log("✅ Mongo connected:", name);
   } catch (e) {
     console.error("❌ Mongo connect failed:", e?.message || e);
   }
@@ -24,3 +51,4 @@ export async function connectMongo() {
 export function mongoReady() {
   return mongoose.connection?.readyState === 1;
 }
+


### PR DESCRIPTION
## Summary
- add robust `src/utils/db.mjs` utility that reads Mongo URI from `MONGODB_URI` or `DB_URL`, supports `MONGODB_DB_NAME`, masks credentials, and logs connection status
- ensure server connects to MongoDB on startup via `connectMongo`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2d8b35b28832b90c63ef5850b1f07