### PR TITLE
feat: add bamboo category sections

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -1,55 +1,48 @@
+import { useEffect, useState } from "react";
 import CategoryCard from "./CategoryCard";
-import { addToCart as add, removeFromCart, inCart, qtyOf, setQty } from "../store/cart";
+import { ProductCard } from "./ProductCard";
+import { Catalog } from "../lib/services";
+import type { Product } from "../lib/types";
 
 const categories = [
-  { title:"Gaming",      note:"120+ cards", icon:"/assets/icons/gaming.svg",    href:"/gaming" },
-  { title:"Streaming",   note:"45+ cards",  icon:"/assets/icons/streaming.svg", href:"/streaming" },
-  { title:"Shopping",    note:"200+ cards", icon:"/assets/icons/shopping.svg",  href:"/shopping" },
-  { title:"Music",       note:"30+ cards",  icon:"/assets/icons/music.svg",     href:"/music" },
-  { title:"Food & Drink",note:"80+ cards",  icon:"/assets/icons/fooddrink.svg", href:"/fooddrink" },
-  { title:"Travel",      note:"25+ cards",  icon:"/assets/icons/travel.svg",    href:"/travel" },
+  { key:"gaming",      title:"Gaming",      note:"120+ cards", icon:"/assets/icons/gaming.svg",    href:"/gaming" },
+  { key:"streaming",   title:"Streaming",   note:"45+ cards",  icon:"/assets/icons/streaming.svg", href:"/streaming" },
+  { key:"shopping",    title:"Shopping",    note:"200+ cards", icon:"/assets/icons/shopping.svg",  href:"/shopping" },
+  { key:"music",       title:"Music",       note:"30+ cards",  icon:"/assets/icons/music.svg",     href:"/music" },
+  { key:"fooddrink",   title:"Food & Drink",note:"80+ cards",  icon:"/assets/icons/fooddrink.svg", href:"/fooddrink" },
+  { key:"travel",      title:"Travel",      note:"25+ cards",  icon:"/assets/icons/travel.svg",    href:"/travel" },
 ];
-
-const featured = [
-  { id:"ps", name:"PlayStation Store Gift Card", price:"$50.00", rating:"4.8", img:"/assets/images/ps.webp" },
-  { id:"netflix", name:"Netflix Gift Card",           price:"$25.00", rating:"4.6", img:"/assets/images/netflix.webp" },
-  { id:"steam", name:"Steam Wallet Code",           price:"$20.00", rating:"4.9", img:"/assets/images/steam.webp" },
-];
-
-function ItemControls({id}:{id:string}){
-  const added = inCart(id);
-  const qty = qtyOf(id);
-  if (!added) return <button className="btn primary" onClick={()=>add({id, name:"", price:0})}>Add to cart</button>;
-  return (
-    <div className="qtyrow">
-      <button className="btn sm" onClick={()=> setQty(id, Math.max(1, qty-1))}>–</button>
-      <span className="qty">{qty}</span>
-      <button className="btn sm" onClick={()=> setQty(id, qty+1)}>+</button>
-      <button className="btn danger" onClick={()=> removeFromCart(id)}>Remove from Cart</button>
-    </div>
-  );
-}
 
 export default function HomePage(){
+  const [sections, setSections] = useState<Record<string, Product[]>>({});
+
+  useEffect(()=>{
+    categories.forEach(c => {
+      Catalog.list({ category: c.key, limit: 4 })
+        .then(res => setSections(s => ({...s, [c.key]: res.products || []})))
+        .catch(()=>{});
+    });
+  },[]);
+
   return (
     <div className="container">
       <h2 className="section-title">Shop by Category</h2>
       <div className="grid categories">
-        {categories.map(c => <CategoryCard key={c.title} {...c} />)}
-      </div>
-
-      <h2 className="section-title" style={{marginTop:32}}>Featured Gift Cards</h2>
-      <div className="grid featured">
-        {featured.map(f=>(
-          <div className="card" key={f.id}>
-            <img src={f.img} alt={f.name} loading="lazy"/>
-            <div className="name">{f.name}</div>
-            <div className="price">{f.price}</div>
-            <div className="rating">Rating: {f.rating}</div>
-            <ItemControls id={f.id} />
-          </div>
+        {categories.map(c => (
+          <CategoryCard key={c.key} icon={c.icon} title={c.title} note={c.note} href={c.href} />
         ))}
       </div>
+
+      {categories.map(c => (
+        <section key={c.key}>
+          <h2 className="section-title" style={{marginTop:32}}>{c.title}</h2>
+          <div className="grid featured">
+            {(sections[c.key] || []).map(p => (
+              <ProductCard key={p.id} product={p} />
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/frontend/src/lib/services.ts
+++ b/frontend/src/lib/services.ts
@@ -14,6 +14,7 @@ export const Catalog = {
     limit?: number;
     currency?: string;
     lang?: string;
+    country?: string;
   }) => {
     const qs = new URLSearchParams();
     qs.set("category", p.category);
@@ -27,6 +28,7 @@ export const Catalog = {
     if (p.limit) qs.set("limit", String(p.limit));
     if (p.currency) qs.set("currency", p.currency);
     if (p.lang) qs.set("lang", p.lang);
+    if (p.country) qs.set("country", p.country);
     return api.get<ProductsResponse>(`/cards?${qs.toString()}`);
   },
 };

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -16,7 +16,7 @@ export default function CategoryPage({category}:{category:CategoryKey}){
   const [sort,setSort] = useState("popular");
   const [view,setView] = useState<"grid"|"list">("grid");
   const [filters,setFilters] = useState<Filters>({ inStock:false });
-  const [platform,setPlatform] = useState<"ALL"|"XBOX"|"PLAYSTATION"|"STEAM">("ALL");
+  const [platform,setPlatform] = useState<"ALL"|"XBOX"|"PLAYSTATION"|"STEAM"|"NINTENDO">("ALL");
   const [regions,setRegions] = useState<string[]>([]);
   const [denoms,setDenoms] = useState<number[]>([]);
   const [facets,setFacets] = useState<Facets>({});

--- a/frontend/src/pages/category/FiltersSidebar.tsx
+++ b/frontend/src/pages/category/FiltersSidebar.tsx
@@ -24,7 +24,7 @@ export default function FiltersSidebar({
   const change = (patch:Partial<Filters>) => onChange({...value, ...patch});
   const platforms = [
     "ALL",
-    ...(facets.platforms?.length ? facets.platforms : ["XBOX","PLAYSTATION","STEAM"]),
+    ...(facets.platforms?.length ? facets.platforms : ["XBOX","PLAYSTATION","NINTENDO","STEAM"]),
   ];
   const toggleRegion = (r:string) => {
     onRegions(regions.includes(r) ? regions.filter(x=>x!==r) : [...regions,r]);

--- a/routers/cards.js
+++ b/routers/cards.js
@@ -24,6 +24,9 @@ router.get("/", async (req, res) => {
       page: q.page || "1",
       limit: q.limit || "48",
       sort: q.sort,
+      CurrencyCode: q.currency,
+      CountryCode: q.country,
+      LanguageCode: q.lang,
     });
 
     let fb = [];

--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -28,10 +28,11 @@ function categorize(x) {
   if (raw.includes("shop")) return "shopping";
   const guess = String(x.platform || x.vendor || x.name || "").toLowerCase();
   if (/xbox|playstation|steam|nintendo|game/.test(guess)) return "gaming";
-  if (/netflix|hulu|disney|prime|stream/.test(guess)) return "streaming";
-  if (/spotify|itunes|music|apple/.test(guess)) return "music";
-  if (/uber|doordash|food|drink|restaurant/.test(guess)) return "fooddrink";
-  if (/air|hotel|travel|flight/.test(guess)) return "travel";
+  if (/twitch|netflix|hulu|disney|prime|stream/.test(guess)) return "streaming";
+  if (/spotify|itunes|music|apple|google\s*play/.test(guess)) return "music";
+  if (/ubereats|uber\s*eats|starbucks|doordash|food|drink|restaurant/.test(guess)) return "fooddrink";
+  if (/airbnb|uber|air|hotel|travel|flight/.test(guess)) return "travel";
+  if (/zalando|amazon|ebay/.test(guess)) return "shopping";
   return "shopping";
 }
 


### PR DESCRIPTION
## Summary
- map Twitch, Nintendo, Google Play and more brands to Bamboo categories
- expose currency/country/language params to Bamboo catalog fetch
- show category sections on the home page with top Bamboo products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix frontend run build` *(fails: vite: not found)*
- `npm --prefix frontend install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b31dbf0428832b826d1529fae23531