### PR TITLE
feat: add currency conversion with cached fx rates

### DIFF
--- a/frontend/src/pages/category/ProductCard.tsx
+++ b/frontend/src/pages/category/ProductCard.tsx
@@ -35,8 +35,8 @@ export default function ProductCard({
           {p.instant && <span className="chip">Instant</span>}
         </div>
         <div className="price" style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
-          {p.oldPrice ? <s className="muted">{money(p.oldPrice, cur)}</s> : null}
-          <strong>{money(p.price, cur)}</strong>
+          {p.oldPrice ? <s className="muted">{money(p.oldPrice, cur, p.currency || "USD")}</s> : null}
+          <strong>{money(p.price, cur, p.currency || "USD")}</strong>
         </div>
       </div>
 
@@ -44,7 +44,9 @@ export default function ProductCard({
         <button
           className="btn primary"
           style={{ marginTop: 10 }}
-          onClick={() => addToCart({ id: p.id, name: p.name, price: p.price, img: p.img })}
+          onClick={() =>
+            addToCart({ id: p.id, name: p.name, price: p.price, img: p.img, currency: p.currency })
+          }
         >
           Add to Cart
         </button>

--- a/frontend/src/pages/checkout/CartPage.tsx
+++ b/frontend/src/pages/checkout/CartPage.tsx
@@ -20,12 +20,18 @@ export default function CartPage(){
     return ()=> clearInterval(t);
   },[]);
 
+  useEffect(()=>{
+    const curH = () => setCurrency(getCurrency());
+    window.addEventListener("currencychange", curH);
+    return () => window.removeEventListener("currencychange", curH);
+  },[]);
+
   const summary: Summary = useMemo(()=>{
-    const sub = subtotal();
+    const sub = subtotal(currency);
     const discount = code.trim().toUpperCase()==="SAVE5" ? Math.min(sub*0.05, 50) : 0;
     const total = Math.max(0, sub - discount);
     return { itemsTotal: totalCount(), discount, subTotal: sub, total };
-  }, [items, code]);
+  }, [items, code, currency]);
 
   const canPay = items.length>0 && emailRe.test(email);
 
@@ -55,7 +61,7 @@ export default function CartPage(){
                 </div>
               </div>
               <div className="co-price">
-                {money(safeMul(it.price, it.qty), currency)}
+                {money(safeMul(it.price, it.qty), currency, it.currency || "USD")}
               </div>
             </div>
           ))}

--- a/frontend/src/pages/checkout/cartUtils.ts
+++ b/frontend/src/pages/checkout/cartUtils.ts
@@ -1,8 +1,32 @@
-export const money = (value:number, currency:string="USD") =>
-  new Intl.NumberFormat("en-US", { style:"currency", currency, maximumFractionDigits:2 }).format(Number.isFinite(value)?value:0);
-
-export const safeMul = (a:any, b:any) => {
-  const x = Number.isFinite(+a)?+a:0;
-  const y = Number.isFinite(+b)?+b:0;
-  return x*y;
+export const convert = (value: number, from: string, to: string) => {
+  if (from === to) return Number.isFinite(value) ? value : 0;
+  try {
+    const fx = JSON.parse(localStorage.getItem("dg_fx") || "{}");
+    const r = fx.rates || {};
+    const base = (fx.base || "USD").toUpperCase();
+    const src = (from || base).toUpperCase();
+    const tgt = (to || base).toUpperCase();
+    if (src === tgt) return Number.isFinite(value) ? value : 0;
+    if (src === base) return value * (r[tgt] || 1);
+    if (tgt === base) return value / (r[src] || 1);
+    return (value / (r[src] || 1)) * (r[tgt] || 1);
+  } catch {
+    return Number.isFinite(value) ? value : 0;
+  }
 };
+
+export const money = (value: number, currency: string = "USD", from?: string) => {
+  const v = convert(Number.isFinite(value) ? value : 0, from || currency, currency);
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2,
+  }).format(v);
+};
+
+export const safeMul = (a: any, b: any) => {
+  const x = Number.isFinite(+a) ? +a : 0;
+  const y = Number.isFinite(+b) ? +b : 0;
+  return x * y;
+};
+

--- a/routers/cards.js
+++ b/routers/cards.js
@@ -74,6 +74,7 @@ router.get("/", async (req, res) => {
           rating: it.rating,
           reviews: it.reviews,
           instant: it.instant,
+          currency: q.currency ? String(q.currency).toUpperCase() : "USD",
         };
       });
 
@@ -105,7 +106,7 @@ router.get("/", async (req, res) => {
     console.log(
       `[cards] gaming=${String(q.category).toLowerCase() === "gaming"} count=${products.length}`
     );
-    res.json({ products, total: products.length, facets });
+    res.json({ products, total: products.length, facets, currency: q.currency ? String(q.currency).toUpperCase() : "USD" });
   } catch (e) {
     console.error("[/api/cards] fatal:", e?.message || e);
     res.json({

--- a/server.mjs
+++ b/server.mjs
@@ -27,7 +27,9 @@ const { catalogRouter } = await import("./src/routes/catalog.mjs");
 const cardsRouter = (await import("./routers/cards.js")).default;
 const searchRouter = (await import("./routers/search.js")).default;
 const { curatedRouter } = await import("./src/routes/curated.mjs");
+const fxUtils = await import("./src/utils/fx.mjs");
 const { fxRouter } = await import("./src/routes/fx.mjs");
+fxUtils.initFxWatcher?.();
 const { ordersRouter } = await import("./src/orders/router.mjs");
 
 // ДІАГНОСТИКА — піднімаємо першою, без залежностей

--- a/src/models/FxRates.mjs
+++ b/src/models/FxRates.mjs
@@ -1,8 +1,0 @@
-import mongoose from "mongoose";
-const FxSchema = new mongoose.Schema({
-  base: { type: String, index: true },
-  rates: { type: Object, required: true },
-  fetchedAt: { type: Date, default: Date.now },
-}, { collection: "fx_rates" });
-
-export const FxRates = mongoose.models.FxRates || mongoose.model("FxRates", FxSchema);

--- a/src/utils/fx.mjs
+++ b/src/utils/fx.mjs
@@ -1,25 +1,43 @@
 import axios from "axios";
-import { FxRates } from "../models/FxRates.mjs";
 
 const PROVIDER = process.env.FX_PROVIDER || "https://api.exchangerate.host/latest";
 const BASE = (process.env.FX_BASE || "USD").toUpperCase();
 const TTL_MIN = Math.max(10, Number(process.env.FX_TTL_MIN || 60));
 
+// simple in-memory cache emulating a redis store
+const cache = new Map();
+
 export async function getRates(base = BASE) {
-  const doc = await FxRates.findOne({ base }).lean();
-  const fresh = doc && (Date.now() - new Date(doc.fetchedAt).getTime() < TTL_MIN*60*1000);
+  base = (base || BASE).toUpperCase();
+  const doc = cache.get(base);
+  const fresh = doc && Date.now() - new Date(doc.fetchedAt).getTime() < TTL_MIN * 60 * 1000;
   if (fresh) return doc;
 
-  const { data } = await axios.get(`${PROVIDER}?base=${encodeURIComponent(base)}`, { timeout: 15000 });
+  const { data } = await axios.get(`${PROVIDER}?base=${encodeURIComponent(base)}`, {
+    timeout: 15000,
+  });
   if (!data?.rates) throw new Error("FX fetch failed");
-  const rec = { base, rates: data.rates, fetchedAt: new Date() };
-  await FxRates.updateOne({ base }, { $set: rec }, { upsert:true });
+  const rec = { base, rates: data.rates, fetchedAt: new Date().toISOString() };
+  cache.set(base, rec);
   return rec;
 }
 
 export function convert(amount, from, to, rates) {
-  const r = rates.rates;
-  if (from === rates.base) return amount * (r[to] || 1);
-  if (to === rates.base)   return amount / (r[from] || 1);
-  return (amount / (r[from] || 1)) * (r[to] || 1);
+  const r = rates.rates || {};
+  const src = (from || rates.base).toUpperCase();
+  const tgt = (to || rates.base).toUpperCase();
+  if (src === tgt) return amount;
+  if (src === rates.base) return amount * (r[tgt] || 1);
+  if (tgt === rates.base) return amount / (r[src] || 1);
+  return (amount / (r[src] || 1)) * (r[tgt] || 1);
+}
+
+let timer;
+export function initFxWatcher() {
+  clearInterval(timer);
+  // prime cache immediately
+  getRates().catch(() => {});
+  timer = setInterval(() => {
+    getRates().catch((e) => console.warn("[fx] refresh failed", e?.message));
+  }, TTL_MIN * 60 * 1000);
 }


### PR DESCRIPTION
## Summary
- cache exchange rates from an external provider with periodic refresh and helper to convert amounts
- expose currency info in card listings for client-side conversion
- update cart and payment flows to recalc prices when users switch currencies

## Testing
- `npm test` *(fails: Missing script: "test"?)*
- `cd frontend && npm test` *(fails: Missing script: "test"?)*

------
https://chatgpt.com/codex/tasks/task_e_68b31fa4c898832bbb6ecc9720d87a50