### PR TITLE
Handle MongoDB connection errors

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -16,8 +16,13 @@ if (!DB_URL) {
   console.warn("DB_URL/MONGODB_URI not set");
 } else {
   console.log(`ℹ️  Mongo connecting to: ${DB_URL}`);
-  await mongoose.connect(DB_URL);
-  console.log(`✅ Mongo connected: ${mongoose.connection.name || "(unknown)"}`);
+  try {
+    const conn = await mongoose.connect(DB_URL);
+    console.log(`✅ Mongo connected: ${conn.connection?.name ?? "(unknown)"}`);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
 }
 
 // 2) Тільки тепер підключаємо роутери (які імпортують моделі)


### PR DESCRIPTION
## Summary
- wrap MongoDB connection in a try/catch and report failures
- log connection name via resolved `mongoose.connect` result

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b32578d3ec832b90ac8587592134b8