### PR TITLE
Fetch Bamboo catalog by category and display on homepage

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -1,55 +1,52 @@
+import { useEffect, useState } from "react";
 import CategoryCard from "./CategoryCard";
-import { addToCart as add, removeFromCart, inCart, qtyOf, setQty } from "../store/cart";
+import { ProductCard } from "./ProductCard";
+import { Catalog } from "../lib/services";
+import type { Product } from "../lib/types";
 
 const categories = [
-  { title:"Gaming",      note:"120+ cards", icon:"/assets/icons/gaming.svg",    href:"/gaming" },
-  { title:"Streaming",   note:"45+ cards",  icon:"/assets/icons/streaming.svg", href:"/streaming" },
-  { title:"Shopping",    note:"200+ cards", icon:"/assets/icons/shopping.svg",  href:"/shopping" },
-  { title:"Music",       note:"30+ cards",  icon:"/assets/icons/music.svg",     href:"/music" },
-  { title:"Food & Drink",note:"80+ cards",  icon:"/assets/icons/fooddrink.svg", href:"/fooddrink" },
-  { title:"Travel",      note:"25+ cards",  icon:"/assets/icons/travel.svg",    href:"/travel" },
+  { key:"gaming",    title:"Gaming",      note:"120+ cards", icon:"/assets/icons/gaming.svg",    href:"/gaming" },
+  { key:"streaming", title:"Streaming",   note:"45+ cards",  icon:"/assets/icons/streaming.svg", href:"/streaming" },
+  { key:"shopping",  title:"Shopping",    note:"200+ cards", icon:"/assets/icons/shopping.svg",  href:"/shopping" },
+  { key:"music",     title:"Music",       note:"30+ cards",  icon:"/assets/icons/music.svg",     href:"/music" },
+  { key:"fooddrink", title:"Food & Drink",note:"80+ cards",  icon:"/assets/icons/fooddrink.svg", href:"/fooddrink" },
+  { key:"travel",    title:"Travel",      note:"25+ cards",  icon:"/assets/icons/travel.svg",    href:"/travel" },
 ];
-
-const featured = [
-  { id:"ps", name:"PlayStation Store Gift Card", price:"$50.00", rating:"4.8", img:"/assets/images/ps.webp" },
-  { id:"netflix", name:"Netflix Gift Card",           price:"$25.00", rating:"4.6", img:"/assets/images/netflix.webp" },
-  { id:"steam", name:"Steam Wallet Code",           price:"$20.00", rating:"4.9", img:"/assets/images/steam.webp" },
-];
-
-function ItemControls({id}:{id:string}){
-  const added = inCart(id);
-  const qty = qtyOf(id);
-  if (!added) return <button className="btn primary" onClick={()=>add({id, name:"", price:0})}>Add to cart</button>;
-  return (
-    <div className="qtyrow">
-      <button className="btn sm" onClick={()=> setQty(id, Math.max(1, qty-1))}>–</button>
-      <span className="qty">{qty}</span>
-      <button className="btn sm" onClick={()=> setQty(id, qty+1)}>+</button>
-      <button className="btn danger" onClick={()=> removeFromCart(id)}>Remove from Cart</button>
-    </div>
-  );
-}
 
 export default function HomePage(){
+  const [items, setItems] = useState<Record<string, Product[]>>({});
+
+  useEffect(() => {
+    Promise.all(
+      categories.map(c =>
+        Catalog.list({ category: c.key, limit: 4 })
+          .then(res => [c.key, res.products || []] as [string, Product[]])
+          .catch(() => [c.key, []] as [string, Product[]])
+      )
+    ).then(entries => {
+      setItems(Object.fromEntries(entries));
+    });
+  }, []);
+
   return (
     <div className="container">
       <h2 className="section-title">Shop by Category</h2>
       <div className="grid categories">
-        {categories.map(c => <CategoryCard key={c.title} {...c} />)}
-      </div>
-
-      <h2 className="section-title" style={{marginTop:32}}>Featured Gift Cards</h2>
-      <div className="grid featured">
-        {featured.map(f=>(
-          <div className="card" key={f.id}>
-            <img src={f.img} alt={f.name} loading="lazy"/>
-            <div className="name">{f.name}</div>
-            <div className="price">{f.price}</div>
-            <div className="rating">Rating: {f.rating}</div>
-            <ItemControls id={f.id} />
-          </div>
+        {categories.map(c => (
+          <CategoryCard key={c.key} icon={c.icon} title={c.title} note={c.note} href={c.href} />
         ))}
       </div>
+
+      {categories.map(c => (
+        items[c.key]?.length ? (
+          <div key={c.key}>
+            <h2 className="section-title" style={{marginTop:32}}>{c.title} Gift Cards</h2>
+            <div className="grid featured">
+              {items[c.key].map(p => <ProductCard key={p.id} product={p} />)}
+            </div>
+          </div>
+        ) : null
+      ))}
     </div>
   );
 }

--- a/utils/bamboo.js
+++ b/utils/bamboo.js
@@ -93,6 +93,7 @@ export function mapProduct(x) {
     platform: x.platform || x.vendor || undefined,
     instant: x.instant ?? true,
     discount: x.discount ? safeN(x.discount, 0) : undefined,
+    denomination: safeN(x.denomination ?? x.faceValue, undefined),
     region: x.region || x.country || "US",
     category: categorize(x),
   };


### PR DESCRIPTION
## Summary
- include denomination in Bamboo product map
- filter Bamboo products by category and expose in cards API
- load Bamboo catalog on homepage for each category

## Testing
- `npm test` *(fails: Missing script: "test")*
- `(cd frontend && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2b6596c70832b9060f9fe7bb10db5