### PR TITLE
feat: add Bamboo catalog export API with caching

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -36,6 +36,7 @@ const fxUtils = await import("./src/utils/fx.mjs");
 const { fxRouter } = await import("./src/routes/fx.mjs");
 fxUtils.initFxWatcher?.();
 const { ordersRouter } = await import("./src/orders/router.mjs");
+const { bambooExportRouter } = await import("./src/routes/bambooExport.mjs");
 
 // ДІАГНОСТИКА — піднімаємо першою, без залежностей
 app.use("/api/diag", diagRouter);
@@ -70,6 +71,7 @@ app.use("/api", catalogRouter);
 app.use("/api", curatedRouter);
 app.use("/api", fxRouter);
 app.use("/api", ordersRouter);
+app.use("/api", bambooExportRouter);
 
 app.get("*", (_req, res) => {
   const indexPath = found && path.join(found, "index.html");

--- a/src/catalog/bambooExport.mjs
+++ b/src/catalog/bambooExport.mjs
@@ -1,0 +1,94 @@
+import axios from "axios";
+import { authHeaders } from "./auth.mjs";
+
+const BASE = process.env.BAMBOO_API_URL || "https://api.bamboocardportal.com";
+const PATH = process.env.BAMBOO_CATALOG_PATH || "/api/integration/v2.0/catalog";
+
+const DEFAULT_PAGE_SIZE = Math.max(1, Number(process.env.CATALOG_PAGE_SIZE || 100));
+const DEFAULT_MAX_PAGES = Math.max(1, Number(process.env.CATALOG_MAX_PAGES || 30));
+
+function qs(params = {}) {
+  const p = new URLSearchParams();
+  if (params.CurrencyCode)   p.set("CurrencyCode", params.CurrencyCode);
+  if (params.CountryCode)    p.set("CountryCode", params.CountryCode);
+  if (params.Name)           p.set("Name", params.Name);
+  if (params.ModifiedDate)   p.set("ModifiedDate", params.ModifiedDate);
+  if (params.ProductId != null) p.set("ProductId", String(params.ProductId));
+  if (params.BrandId != null)   p.set("BrandId", String(params.BrandId));
+  if (params.TargetCurrency) p.set("TargetCurrency", params.TargetCurrency);
+  p.set("PageSize", String(params.PageSize ?? DEFAULT_PAGE_SIZE));
+  p.set("PageIndex", String(params.PageIndex ?? 0));
+  return p.toString();
+}
+
+async function fetchPage(query) {
+  const headers = { "Content-Type": "application/json", ...(await authHeaders()) };
+  const url = `${BASE}${PATH}?${qs(query)}`;
+  const { data, status } = await axios.get(url, { headers, timeout: 20000 });
+  if (status !== 200) throw new Error(`Bamboo status ${status}`);
+  const items = Array.isArray(data?.items) ? data.items : [];
+  return { items, data };
+}
+
+// Перетворення брендів+продуктів у плоскі рядки
+function flatten(items, combo) {
+  const rows = [];
+  for (const b of items) {
+    const brandName = b?.name || "";
+    const brandId = b?.brandId ?? null;
+    const bCountry = b?.countryCode || combo.CountryCode || null;
+    const bCurrency = b?.currencyCode || combo.CurrencyCode || null;
+    const modifiedDate = b?.modifiedDate || null;
+    const products = Array.isArray(b?.products) ? b.products : [];
+    for (const p of products) {
+      rows.push({
+        brandName,
+        brandId,
+        productId: p?.id,
+        productName: p?.name || brandName,
+        priceMin: p?.price?.min ?? null,
+        priceMax: p?.price?.max ?? null,
+        priceCurrency: p?.price?.currencyCode || bCurrency,
+        countryCode: bCountry,
+        currencyCode: bCurrency,
+        modifiedDate,
+      });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Витягує ВСІ сторінки для заданих фільтрів.
+ */
+export async function exportAllProducts({
+  CountryCode,
+  CurrencyCode,
+  Name,
+  ModifiedDate,
+  ProductId,
+  BrandId,
+  TargetCurrency,
+  pageSize = DEFAULT_PAGE_SIZE,
+  maxPages = DEFAULT_MAX_PAGES,
+}) {
+  const combo = { CountryCode, CurrencyCode };
+  const all = [];
+  for (let page = 0; page < maxPages; page++) {
+    const { items } = await fetchPage({
+      CountryCode,
+      CurrencyCode,
+      Name,
+      ModifiedDate,
+      ProductId,
+      BrandId,
+      TargetCurrency,
+      PageSize: pageSize,
+      PageIndex: page,
+    });
+    if (!items.length) break;
+    all.push(...flatten(items, combo));
+    if (items.length < pageSize) break;
+  }
+  return all;
+}

--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+const DumpSchema = new mongoose.Schema(
+  {
+    key: { type: String, index: true, unique: true },
+    filters: { type: Object, default: {} },
+    rows: { type: Array, default: [] }, // плоскі товари
+    updatedAt: { type: Date, default: Date.now },
+  },
+  { collection: "bamboo_dump" }
+);
+
+// безпечна реєстрація моделі
+const existing =
+  (mongoose.connection && mongoose.connection.models && mongoose.connection.models.BambooDump) ||
+  (mongoose.models && mongoose.models.BambooDump) ||
+  null;
+
+export const BambooDump = existing || mongoose.model("BambooDump", DumpSchema);
+export default BambooDump;

--- a/src/routes/bambooExport.mjs
+++ b/src/routes/bambooExport.mjs
@@ -1,0 +1,149 @@
+import express from "express";
+import { exportAllProducts } from "../catalog/bambooExport.mjs";
+import BambooDump from "../models/BambooDump.mjs";
+
+export const bambooExportRouter = express.Router();
+
+const TTL_MIN = Math.max(10, Number(process.env.CATALOG_TTL_MIN || 60));
+
+// Будуємо ключ кешу на основі фільтрів
+function cacheKey(q) {
+  const parts = [
+    q.CountryCode || "*",
+    q.CurrencyCode || "*",
+    q.Name || "",
+    q.ModifiedDate || "",
+    q.ProductId != null ? `pid:${q.ProductId}` : "",
+    q.BrandId != null ? `bid:${q.BrandId}` : "",
+    q.TargetCurrency || "",
+    `ps:${q.PageSize || ""}`,
+    `mp:${q.maxPages || ""}`,
+  ];
+  return `dump:${parts.join("|")}`;
+}
+
+// Загальний хелпер: отримати рядки (з кеша або з Bamboo)
+async function getRowsWithCache(q, force) {
+  const key = cacheKey(q);
+  if (!force) {
+    const doc = await BambooDump.findOne({ key }).lean();
+    const fresh = doc && (Date.now() - new Date(doc.updatedAt).getTime() < TTL_MIN * 60 * 1000);
+    if (fresh) return { rows: doc.rows, cached: true, key };
+  }
+  const rows = await exportAllProducts(q);
+  await BambooDump.updateOne(
+    { key },
+    { $set: { key, filters: q, rows, updatedAt: new Date() } },
+    { upsert: true }
+  );
+  return { rows, cached: false, key };
+}
+
+// GET /api/bamboo/export.json?CountryCode=...&CurrencyCode=...&PageSize=100&maxPages=30&force=1&limit=1000
+bambooExportRouter.get("/bamboo/export.json", async (req, res) => {
+  try {
+    const q = {
+      CountryCode: req.query.CountryCode,
+      CurrencyCode: req.query.CurrencyCode,
+      Name: req.query.Name,
+      ModifiedDate: req.query.ModifiedDate,
+      ProductId: req.query.ProductId ? Number(req.query.ProductId) : undefined,
+      BrandId: req.query.BrandId ? Number(req.query.BrandId) : undefined,
+      TargetCurrency: req.query.TargetCurrency,
+      PageSize: req.query.PageSize ? Number(req.query.PageSize) : undefined,
+      maxPages: req.query.maxPages ? Number(req.query.maxPages) : undefined,
+    };
+    const force = String(req.query.force || "") === "1";
+    const limit = req.query.limit ? Number(req.query.limit) : undefined;
+
+    const { rows, cached, key } = await getRowsWithCache(q, force);
+    const out = Array.isArray(rows) ? (limit ? rows.slice(0, limit) : rows) : [];
+    res.json({
+      ok: true,
+      count: out.length,
+      cached,
+      key,
+      filters: q,
+      rows: out,
+    });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.response?.data || e?.message || "export failed" });
+  }
+});
+
+// GET /api/bamboo/export.ndjson?... — стрім по рядку на продукт
+bambooExportRouter.get("/bamboo/export.ndjson", async (req, res) => {
+  try {
+    const q = {
+      CountryCode: req.query.CountryCode,
+      CurrencyCode: req.query.CurrencyCode,
+      Name: req.query.Name,
+      ModifiedDate: req.query.ModifiedDate,
+      ProductId: req.query.ProductId ? Number(req.query.ProductId) : undefined,
+      BrandId: req.query.BrandId ? Number(req.query.BrandId) : undefined,
+      TargetCurrency: req.query.TargetCurrency,
+      PageSize: req.query.PageSize ? Number(req.query.PageSize) : undefined,
+      maxPages: req.query.maxPages ? Number(req.query.maxPages) : undefined,
+    };
+    const force = String(req.query.force || "") === "1";
+    const { rows } = await getRowsWithCache(q, force);
+
+    res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
+    for (const r of rows) {
+      res.write(JSON.stringify(r) + "\n");
+    }
+    res.end();
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "ndjson failed" });
+  }
+});
+
+// GET /api/bamboo/export.csv?... — CSV для скачування
+bambooExportRouter.get("/bamboo/export.csv", async (req, res) => {
+  try {
+    const q = {
+      CountryCode: req.query.CountryCode,
+      CurrencyCode: req.query.CurrencyCode,
+      Name: req.query.Name,
+      ModifiedDate: req.query.ModifiedDate,
+      ProductId: req.query.ProductId ? Number(req.query.ProductId) : undefined,
+      BrandId: req.query.BrandId ? Number(req.query.BrandId) : undefined,
+      TargetCurrency: req.query.TargetCurrency,
+      PageSize: req.query.PageSize ? Number(req.query.PageSize) : undefined,
+      maxPages: req.query.maxPages ? Number(req.query.maxPages) : undefined,
+    };
+    const force = String(req.query.force || "") === "1";
+    const { rows } = await getRowsWithCache(q, force);
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", "attachment; filename=\"bamboo_export.csv\"");
+
+    const header = [
+      "brandName",
+      "brandId",
+      "productId",
+      "productName",
+      "priceMin",
+      "priceMax",
+      "priceCurrency",
+      "countryCode",
+      "currencyCode",
+      "modifiedDate",
+    ];
+    res.write(header.join(",") + "\n");
+
+    for (const r of rows) {
+      const line = header
+        .map((k) => {
+          const v = r[k] ?? "";
+          const s = String(v).replace(/"/g, '""');
+          return `"${s}"`;
+        })
+        .join(",");
+      res.write(line + "\n");
+    }
+    res.end();
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "csv failed" });
+  }
+});


### PR DESCRIPTION
## Summary
- add BambooDump model for catalog dump caching
- implement Bamboo catalog export with pagination and flattening
- expose JSON, NDJSON, and CSV export routes using cache
- wire bamboo export router into server

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3ec9ddcd8832b80621125330665c1