### PR TITLE
refactor: cache curated gaming route

### DIFF
--- a/src/routes/curated.mjs
+++ b/src/routes/curated.mjs
@@ -7,12 +7,11 @@ export const curatedRouter = express.Router();
 const TTL_MIN = Math.max(5, Number(process.env.CATALOG_TTL_MIN || 60));
 const KEY = "curated:v1";
 
-async function ensureFresh({ countries, currencies }) {
-  const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
-  const fresh =
-    doc && Date.now() - new Date(doc.updatedAt).getTime() < TTL_MIN * 60 * 1000;
-  if (fresh) return doc.data;
+// простий глобальний лок, аби не запускати паралельні фетчі
+let refreshing = null;
+let lastErr = null;
 
+async function buildAndCache({ countries, currencies }) {
   const { categories, meta } = await fetchMatrix({ countries, currencies });
   const data = { categories, meta, updatedAt: new Date().toISOString() };
   await CuratedCatalog.updateOne(
@@ -23,6 +22,43 @@ async function ensureFresh({ countries, currencies }) {
   return data;
 }
 
+async function ensureFresh({ countries, currencies, force = false }) {
+  const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
+  const fresh =
+    doc && Date.now() - new Date(doc.updatedAt).getTime() < TTL_MIN * 60 * 1000;
+
+  if (!force && fresh) return doc.data;
+
+  // якщо вже триває оновлення — чекаємо існуючий проміс
+  if (refreshing) {
+    try {
+      await refreshing;
+    } catch (_) {}
+    const again = await CuratedCatalog.findOne({ key: KEY }).lean();
+    return again?.data || doc?.data || { categories: {}, meta: {} };
+  }
+
+  // стартуємо оновлення
+  refreshing = buildAndCache({ countries, currencies })
+    .then((data) => {
+      lastErr = null;
+      return data;
+    })
+    .catch((e) => {
+      lastErr = e;
+      // на фатальній помилці повертаємо попередній кеш (якщо він був)
+      return doc?.data || { categories: {}, meta: {}, error: e?.message || "refresh failed" };
+    })
+    .finally(() => {
+      refreshing = null;
+    });
+
+  return refreshing;
+}
+
+// === API ===
+
+// GET /api/curated — віддає з кешу (оновлює лише за TTL)
 curatedRouter.get("/curated", async (req, res) => {
   try {
     const split = (s) =>
@@ -32,25 +68,61 @@ curatedRouter.get("/curated", async (req, res) => {
         .filter(Boolean);
     const countries = req.query.countries ? split(req.query.countries) : undefined;
     const currencies = req.query.currencies ? split(req.query.currencies) : undefined;
-    const data = await ensureFresh({ countries, currencies });
-    res.json({ ok: true, ...data });
+
+    const data = await ensureFresh({ countries, currencies, force: false });
+    res.json({ ok: true, ...data, lastErr: lastErr ? String(lastErr) : null });
   } catch (e) {
-    res
-      .status(200)
-      .json({ ok: false, error: e?.response?.data || e?.message || "failed" });
+    res.status(200).json({ ok: false, error: e?.response?.data || e?.message || "failed" });
   }
 });
 
-// GET /api/curated/gaming - повертає ТІЛЬКИ Gaming
-curatedRouter.get("/curated/gaming", async (req, res) => {
+// POST /api/curated/refresh — явне оновлення кешу (1 раз, під локом)
+curatedRouter.post("/curated/refresh", async (req, res) => {
   try {
-    // підхопимо дефолтну матрицю (в т.ч. нові валюти з ENV)
-    const { categories, meta } = await fetchMatrix({});
-    const gaming = categories?.gaming || [];
-    res.json({ ok: true, count: gaming.length, items: gaming, meta });
+    const split = (s) =>
+      String(s || "")
+        .split(",")
+        .map((x) => x.trim())
+        .filter(Boolean);
+    const countries = req.query.countries ? split(req.query.countries) : undefined;
+    const currencies = req.query.currencies ? split(req.query.currencies) : undefined;
+
+    const data = await ensureFresh({ countries, currencies, force: true });
+    const gamingCount = (data.categories?.gaming || []).length;
+    res.json({ ok: true, refreshed: true, gamingCount, meta: data.meta });
   } catch (e) {
-    res
-      .status(200)
-      .json({ ok:false, error: e?.response?.data || e?.message || "failed" });
+    // навіть при помилці (наприклад, 429) віддаємо останній кеш
+    const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
+    res.status(200).json({
+      ok: false,
+      error: e?.response?.data || e?.message || "refresh failed",
+      cached: !!doc,
+      cachedUpdatedAt: doc?.updatedAt || null,
+    });
+  }
+});
+
+// GET /api/curated/gaming — ТІЛЬКИ з кешу (жодних прямих звернень до Bamboo)
+curatedRouter.get("/curated/gaming", async (_req, res) => {
+  try {
+    const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
+    if (!doc?.data) {
+      // якщо кешу ще не було — підказуємо викликати refresh один раз
+      return res.status(200).json({
+        ok: false,
+        error: "Cache empty. Call POST /api/curated/refresh once, then retry.",
+      });
+    }
+    const gaming = doc.data.categories?.gaming || [];
+    res.json({
+      ok: true,
+      count: gaming.length,
+      items: gaming,
+      meta: doc.data.meta,
+      updatedAt: doc.updatedAt,
+      lastErr: lastErr ? String(lastErr) : null,
+    });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "failed" });
   }
 });


### PR DESCRIPTION
## Summary
- cache curated responses with ensureFresh and anti-storm lock
- always return cached data even on refresh 429 errors
- serve /api/curated/gaming only from cache

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3f4150100832b98f2321b436fcc28