### PR TITLE
feat: add curated catalog caching

### DIFF
--- a/src/catalog/cache.mjs
+++ b/src/catalog/cache.mjs
@@ -1,0 +1,128 @@
+import CuratedCatalog from "../models/CuratedCatalog.mjs";
+import { fetchMatrix } from "./bambooMatrix.mjs";
+
+/**
+ * Глобальний (на процес) лок, щоб не запускати паралельних оновлень
+ */
+let refreshing = null;
+/** Час до якого заборонено ходити в Bamboo після 429/помилки */
+let backoffUntil = 0;
+/** Остання помилка оновлення (для діагностики) */
+let lastError = null;
+
+const TTL_MIN = Math.max(5, Number(process.env.CATALOG_TTL_MIN || 60));
+const BACKOFF_MIN = Math.max(5, Number(process.env.CATALOG_BACKOFF_MIN || 30));
+const KEY = "curated:v1";
+
+function now() { return Date.now(); }
+
+async function readCache() {
+  return CuratedCatalog.findOne({ key: KEY }).lean();
+}
+
+async function writeCache(data) {
+  await CuratedCatalog.updateOne(
+    { key: KEY },
+    { $set: { data, updatedAt: new Date() } },
+    { upsert: true }
+  );
+}
+
+function isFresh(ts) {
+  return ts && (now() - new Date(ts).getTime() < TTL_MIN * 60 * 1000);
+}
+
+/**
+ * Основний метод: повертає дані з кешу, а при потребі — оновлює (керовано).
+ * @param {{countries?: string[], currencies?: string[], force?: boolean}} opts
+ */
+export async function getCuratedFromCache(opts = {}) {
+  const { countries, currencies, force = false } = opts;
+
+  // 1) читаємо кеш
+  const doc = await readCache();
+  const fresh = doc?.data && isFresh(doc.updatedAt);
+
+  // 2) якщо свіжий — віддаємо негайно
+  if (!force && fresh) {
+    return { ok: true, source: "cache", data: doc.data, lastError };
+  }
+
+  // 3) якщо діє backoff — віддаємо останній кеш (або порожньо), не ходимо в Bamboo
+  if (!force && now() < backoffUntil) {
+    return {
+      ok: true,
+      source: "stale-cache",
+      data: doc?.data || { categories: {}, meta: {} },
+      lastError,
+      backoffUntil,
+    };
+  }
+
+  // 4) якщо вже оновлюється — чекаємо один проміс і віддаємо результат (або кеш)
+  if (refreshing) {
+    try {
+      await refreshing;
+    } catch (_) {}
+    const after = await readCache();
+    return {
+      ok: true,
+      source: "cache-after-refresh",
+      data: after?.data || doc?.data || { categories: {}, meta: {} },
+      lastError,
+      backoffUntil,
+    };
+  }
+
+  // 5) стартуємо оновлення (під локом)
+  refreshing = (async () => {
+    try {
+      const { categories, meta } = await fetchMatrix({ countries, currencies });
+      const data = { categories, meta, updatedAt: new Date().toISOString() };
+      await writeCache(data);
+      lastError = null;
+    } catch (e) {
+      // при помилці виставляємо backoff
+      lastError = e?.response?.data || e?.message || String(e);
+      backoffUntil = now() + BACKOFF_MIN * 60 * 1000;
+    }
+  })();
+
+  // 6) Не блокуємо відповідь: віддаємо те, що є в кеші (або порожньо)
+  const data = doc?.data || { categories: {}, meta: {} };
+  return {
+    ok: true,
+    source: doc ? "stale-cache-refreshing" : "empty-refreshing",
+    data,
+    lastError,
+    backoffUntil,
+  };
+}
+
+/**
+ * Примусове оновлення (адмін-дія або CRON).
+ */
+export async function refreshCuratedNow(opts = {}) {
+  if (refreshing) {
+    await refreshing; // дочекаємось активного
+  }
+  try {
+    refreshing = (async () => {
+      const { categories, meta } = await fetchMatrix(opts);
+      const data = { categories, meta, updatedAt: new Date().toISOString() };
+      await writeCache(data);
+      lastError = null;
+      return data;
+    })();
+    const data = await refreshing;
+    return { ok: true, data };
+  } catch (e) {
+    lastError = e?.response?.data || e?.message || String(e);
+    backoffUntil = now() + BACKOFF_MIN * 60 * 1000;
+    const doc = await readCache();
+    return { ok: false, data: doc?.data || { categories: {}, meta: {} }, error: lastError, backoffUntil };
+  } finally {
+    refreshing = null;
+  }
+}
+

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,21 +1,15 @@
 import mongoose from "mongoose";
 
-const CuratedSchema = new mongoose.Schema(
-  {
-    key: { type: String, index: true, unique: true },
-    data: { type: Object, required: true },
-    updatedAt: { type: Date, default: Date.now },
-  },
-  { collection: "curated_catalog" }
-);
+const CuratedSchema = new mongoose.Schema({
+  key: { type: String, index: true, unique: true },
+  data: { type: Object, required: true },
+  updatedAt: { type: Date, default: Date.now },
+}, { collection: "curated_catalog" });
 
-// Безпечний доступ, щоб не падати коли mongoose.models ще не готовий
-const existingModel =
-  (mongoose.connection && mongoose.connection.models && mongoose.connection.models.CuratedCatalog) ||
-  (mongoose.models && mongoose.models.CuratedCatalog) ||
+const existing =
+  (mongoose.connection?.models?.CuratedCatalog) ||
+  (mongoose.models?.CuratedCatalog) ||
   null;
 
-export const CuratedCatalog =
-  existingModel || mongoose.model("CuratedCatalog", CuratedSchema);
-
+export const CuratedCatalog = existing || mongoose.model("CuratedCatalog", CuratedSchema);
 export default CuratedCatalog;

--- a/src/routes/curated.mjs
+++ b/src/routes/curated.mjs
@@ -1,128 +1,44 @@
 import express from "express";
-import CuratedCatalog from "../models/CuratedCatalog.mjs";
-import { fetchMatrix } from "../catalog/bambooMatrix.mjs";
+import { getCuratedFromCache, refreshCuratedNow } from "../catalog/cache.mjs";
 
 export const curatedRouter = express.Router();
 
-const TTL_MIN = Math.max(5, Number(process.env.CATALOG_TTL_MIN || 60));
-const KEY = "curated:v1";
-
-// простий глобальний лок, аби не запускати паралельні фетчі
-let refreshing = null;
-let lastErr = null;
-
-async function buildAndCache({ countries, currencies }) {
-  const { categories, meta } = await fetchMatrix({ countries, currencies });
-  const data = { categories, meta, updatedAt: new Date().toISOString() };
-  await CuratedCatalog.updateOne(
-    { key: KEY },
-    { $set: { data, updatedAt: new Date() } },
-    { upsert: true }
-  );
-  return data;
-}
-
-async function ensureFresh({ countries, currencies, force = false }) {
-  const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
-  const fresh =
-    doc && Date.now() - new Date(doc.updatedAt).getTime() < TTL_MIN * 60 * 1000;
-
-  if (!force && fresh) return doc.data;
-
-  // якщо вже триває оновлення — чекаємо існуючий проміс
-  if (refreshing) {
-    try {
-      await refreshing;
-    } catch (_) {}
-    const again = await CuratedCatalog.findOne({ key: KEY }).lean();
-    return again?.data || doc?.data || { categories: {}, meta: {} };
-  }
-
-  // стартуємо оновлення
-  refreshing = buildAndCache({ countries, currencies })
-    .then((data) => {
-      lastErr = null;
-      return data;
-    })
-    .catch((e) => {
-      lastErr = e;
-      // на фатальній помилці повертаємо попередній кеш (якщо він був)
-      return doc?.data || { categories: {}, meta: {}, error: e?.message || "refresh failed" };
-    })
-    .finally(() => {
-      refreshing = null;
-    });
-
-  return refreshing;
-}
-
-// === API ===
-
-// GET /api/curated — віддає з кешу (оновлює лише за TTL)
+// GET /api/curated — тільки з кешу; якщо TTL вийшов — тригерне оновлення у фоні
 curatedRouter.get("/curated", async (req, res) => {
   try {
-    const split = (s) =>
-      String(s || "")
-        .split(",")
-        .map((x) => x.trim())
-        .filter(Boolean);
+    const split = (s) => String(s || "").split(",").map(x => x.trim()).filter(Boolean);
     const countries = req.query.countries ? split(req.query.countries) : undefined;
     const currencies = req.query.currencies ? split(req.query.currencies) : undefined;
 
-    const data = await ensureFresh({ countries, currencies, force: false });
-    res.json({ ok: true, ...data, lastErr: lastErr ? String(lastErr) : null });
-  } catch (e) {
-    res.status(200).json({ ok: false, error: e?.response?.data || e?.message || "failed" });
-  }
-});
-
-// POST /api/curated/refresh — явне оновлення кешу (1 раз, під локом)
-curatedRouter.post("/curated/refresh", async (req, res) => {
-  try {
-    const split = (s) =>
-      String(s || "")
-        .split(",")
-        .map((x) => x.trim())
-        .filter(Boolean);
-    const countries = req.query.countries ? split(req.query.countries) : undefined;
-    const currencies = req.query.currencies ? split(req.query.currencies) : undefined;
-
-    const data = await ensureFresh({ countries, currencies, force: true });
-    const gamingCount = (data.categories?.gaming || []).length;
-    res.json({ ok: true, refreshed: true, gamingCount, meta: data.meta });
-  } catch (e) {
-    // навіть при помилці (наприклад, 429) віддаємо останній кеш
-    const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
-    res.status(200).json({
-      ok: false,
-      error: e?.response?.data || e?.message || "refresh failed",
-      cached: !!doc,
-      cachedUpdatedAt: doc?.updatedAt || null,
-    });
-  }
-});
-
-// GET /api/curated/gaming — ТІЛЬКИ з кешу (жодних прямих звернень до Bamboo)
-curatedRouter.get("/curated/gaming", async (_req, res) => {
-  try {
-    const doc = await CuratedCatalog.findOne({ key: KEY }).lean();
-    if (!doc?.data) {
-      // якщо кешу ще не було — підказуємо викликати refresh один раз
-      return res.status(200).json({
-        ok: false,
-        error: "Cache empty. Call POST /api/curated/refresh once, then retry.",
-      });
-    }
-    const gaming = doc.data.categories?.gaming || [];
-    res.json({
-      ok: true,
-      count: gaming.length,
-      items: gaming,
-      meta: doc.data.meta,
-      updatedAt: doc.updatedAt,
-      lastErr: lastErr ? String(lastErr) : null,
-    });
+    const out = await getCuratedFromCache({ countries, currencies, force: false });
+    res.json({ ok: true, ...out });
   } catch (e) {
     res.status(200).json({ ok: false, error: e?.message || "failed" });
   }
 });
+
+// POST /api/curated/refresh — примусове оновлення (викликати рідко)
+curatedRouter.post("/curated/refresh", async (req, res) => {
+  try {
+    const split = (s) => String(s || "").split(",").map(x => x.trim()).filter(Boolean);
+    const countries = req.query.countries ? split(req.query.countries) : undefined;
+    const currencies = req.query.currencies ? split(req.query.currencies) : undefined;
+
+    const out = await refreshCuratedNow({ countries, currencies });
+    res.json({ ok: true, ...out });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "refresh failed" });
+  }
+});
+
+// GET /api/curated/gaming — тільки з кешу
+curatedRouter.get("/curated/gaming", async (_req, res) => {
+  try {
+    const out = await getCuratedFromCache({});
+    const gaming = out.data?.categories?.gaming || [];
+    res.json({ ok: true, count: gaming.length, items: gaming, meta: out.data?.meta, source: out.source });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "failed" });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add curated catalog cache service with TTL and backoff
- route curated API and bamboo router through cache
- use safe CuratedCatalog model initialization

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3f62a18f4832ba7413f4a2c4b1afc