### PR TITLE
refactor: unify model exports and add curated cache status

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -2,18 +2,17 @@ import mongoose from "mongoose";
 
 const DumpSchema = new mongoose.Schema(
   {
-    key: { type: String, index: true, unique: true },  // унікальний ключ кешу (фільтри)
+    key: { type: String, index: true, unique: true },
     filters: { type: Object, default: {} },
-    rows: { type: Array, default: [] },                // плоский список товарів
+    rows: { type: Array, default: [] },
     updatedAt: { type: Date, default: Date.now },
   },
   { collection: "bamboo_dump" }
 );
 
-const existing =
+const Model =
+  mongoose.models?.BambooDump ||
   (mongoose.connection?.models?.BambooDump) ||
-  (mongoose.models?.BambooDump) ||
-  null;
+  mongoose.model("BambooDump", DumpSchema);
 
-export const BambooDump = existing || mongoose.model("BambooDump", DumpSchema);
-export default BambooDump;
+export default Model;

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -9,10 +9,11 @@ const CuratedSchema = new mongoose.Schema(
   { collection: "curated_catalog" }
 );
 
-const existing =
+// реєстрація моделі один раз
+const Model =
+  mongoose.models?.CuratedCatalog ||
   (mongoose.connection?.models?.CuratedCatalog) ||
-  (mongoose.models?.CuratedCatalog) ||
-  null;
+  mongoose.model("CuratedCatalog", CuratedSchema);
 
-export const CuratedCatalog = existing || mongoose.model("CuratedCatalog", CuratedSchema);
-export default CuratedCatalog;
+// ВАЖЛИВО: тільки default-експорт
+export default Model;

--- a/src/routes/curated.mjs
+++ b/src/routes/curated.mjs
@@ -1,11 +1,12 @@
 import express from "express";
 import { getCuratedFromCache, refreshCuratedNow } from "../catalog/cache.mjs";
+import CuratedCatalog from "../models/CuratedCatalog.mjs"; // для status
 
 export const curatedRouter = express.Router();
 
 const split = (s) => String(s || "").split(",").map(x => x.trim()).filter(Boolean);
 
-// GET /api/curated — кеш; при TTL запускає фонове оновлення
+// GET /api/curated — читаємо з кешу (оновлення у фоні при TTL)
 curatedRouter.get("/curated", async (req, res) => {
   try {
     const countries = req.query.countries ? split(req.query.countries) : undefined;
@@ -17,7 +18,7 @@ curatedRouter.get("/curated", async (req, res) => {
   }
 });
 
-// POST /api/curated/refresh — ручне оновлення кешу
+// POST /api/curated/refresh — лишаємо як було
 curatedRouter.post("/curated/refresh", async (req, res) => {
   try {
     const countries = req.query.countries ? split(req.query.countries) : undefined;
@@ -29,7 +30,19 @@ curatedRouter.post("/curated/refresh", async (req, res) => {
   }
 });
 
-// GET /api/curated/gaming — лише кеш
+// ✅ ДОДАТИ GET-АЛІАС, бо користувач викликає з браузера GET
+curatedRouter.get("/curated/refresh", async (req, res) => {
+  try {
+    const countries = req.query.countries ? split(req.query.countries) : undefined;
+    const currencies = req.query.currencies ? split(req.query.currencies) : undefined;
+    const out = await refreshCuratedNow({ countries, currencies });
+    res.json({ ok: true, ...out, method: "GET" });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "refresh failed" });
+  }
+});
+
+// GET /api/curated/gaming — з кешу
 curatedRouter.get("/curated/gaming", async (_req, res) => {
   try {
     const out = await getCuratedFromCache({});
@@ -39,3 +52,20 @@ curatedRouter.get("/curated/gaming", async (_req, res) => {
     res.status(200).json({ ok: false, error: e?.message || "failed" });
   }
 });
+
+// ✅ ДОДАТИ діагностику: чи є документ у БД і коли оновлено
+curatedRouter.get("/curated/status", async (_req, res) => {
+  try {
+    const doc = await CuratedCatalog.findOne({ key: "curated:v1" }).lean();
+    res.json({
+      ok: true,
+      hasDoc: !!doc,
+      updatedAt: doc?.updatedAt || null,
+      keys: doc ? Object.keys(doc?.data?.categories || {}) : [],
+      meta: doc?.data?.meta || null,
+    });
+  } catch (e) {
+    res.status(200).json({ ok: false, error: e?.message || "status failed" });
+  }
+});
+


### PR DESCRIPTION
## Summary
- fix CuratedCatalog and BambooDump models to default export with single registration
- add GET alias and status diagnostics to curated routes
- ensure curated router stays wired after Mongo connect

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b41d0d620c832ba3bb4b577497686b