### PR TITLE
Standardize CuratedCatalog export and add mongoose debug endpoint

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -26,6 +26,7 @@ if (!DB_URL) {
 
 // 2) Тільки тепер підключаємо роутери (які імпортують моделі)
 const { diagRouter } = await import("./src/routes/diag.mjs");
+const { debugRouter } = await import("./src/routes/debug.mjs");
 const { bambooMatrixRouter } = await import("./src/routes/bamboo-matrix.mjs");
 const { catalogRouter } = await import("./src/routes/catalog.mjs");
 const cardsRouter = (await import("./routers/cards.js")).default;
@@ -43,6 +44,7 @@ app.use("/api", express.json());
 // ДІАГНОСТИКА — піднімаємо першою, без залежностей
 app.use("/api/diag", diagRouter);
 app.use("/api/diag", bambooMatrixRouter);
+app.use("/api", debugRouter);
 app.get("/api/health", (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
 app.get("/healthz", (_req, res) => res.json({ ok: true }));
 

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -9,11 +9,10 @@ const CuratedSchema = new mongoose.Schema(
   { collection: "curated_catalog" }
 );
 
-// реєстрація моделі один раз
 const Model =
   mongoose.models?.CuratedCatalog ||
   (mongoose.connection?.models?.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
-// ВАЖЛИВО: тільки default-експорт
+// ЄДИНИЙ вірний експорт
 export default Model;

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -1,0 +1,26 @@
+import express from "express";
+import mongoose from "mongoose";
+import CuratedCatalog from "../models/CuratedCatalog.mjs"; // перевіряємо сам імпорт
+
+export const debugRouter = express.Router();
+
+debugRouter.get("/debug/mongoose", async (_req, res) => {
+  try {
+    const names = mongoose.modelNames();            // зареєстровані моделі
+    const typeOfModel = typeof CuratedCatalog;      // має бути "function"
+    const protoKeys = CuratedCatalog ? Object.getOwnPropertyNames(CuratedCatalog) : [];
+    res.json({
+      ok: true,
+      connected: !!mongoose.connection?.readyState,
+      db: mongoose.connection?.name || null,
+      modelNames: names,
+      curatedCatalog: {
+        typeof: typeOfModel,
+        hasFindOne: !!CuratedCatalog?.findOne,
+        keys: protoKeys.slice(0, 10),
+      },
+    });
+  } catch (e) {
+    res.json({ ok: false, error: e?.message || String(e) });
+  }
+});


### PR DESCRIPTION
## Summary
- ensure `CuratedCatalog` model exports a single default mongoose model
- expose `/api/debug/mongoose` to inspect Mongoose registrations
- wire the debug router into server startup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4216b29c4832b8e95426c37b713cf