### PR TITLE
feat: add Mongoose debug endpoint and dual model exports

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import mongoose from "mongoose";
+import { debugRouter } from "./src/routes/debug.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,7 +27,6 @@ if (!DB_URL) {
 
 // 2) Тільки тепер підключаємо роутери (які імпортують моделі)
 const { diagRouter } = await import("./src/routes/diag.mjs");
-const { debugRouter } = await import("./src/routes/debug.mjs");
 const { bambooMatrixRouter } = await import("./src/routes/bamboo-matrix.mjs");
 const { catalogRouter } = await import("./src/routes/catalog.mjs");
 const cardsRouter = (await import("./routers/cards.js")).default;

--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -10,9 +10,10 @@ const DumpSchema = new mongoose.Schema(
   { collection: "bamboo_dump" }
 );
 
-const Model =
+const BambooDumpModel =
   mongoose.models?.BambooDump ||
   (mongoose.connection?.models?.BambooDump) ||
   mongoose.model("BambooDump", DumpSchema);
 
-export default Model;
+export const BambooDump = BambooDumpModel;
+export default BambooDumpModel;

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -9,10 +9,12 @@ const CuratedSchema = new mongoose.Schema(
   { collection: "curated_catalog" }
 );
 
-const Model =
+// Реєструємо один раз
+const CuratedCatalogModel =
   mongoose.models?.CuratedCatalog ||
   (mongoose.connection?.models?.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
-// ЄДИНИЙ вірний експорт
-export default Model;
+// 🔑 Експортуємо і як default, і як named — щоб спіймати всі стилі імпорту
+export const CuratedCatalog = CuratedCatalogModel;
+export default CuratedCatalogModel;

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -1,23 +1,29 @@
 import express from "express";
 import mongoose from "mongoose";
-import CuratedCatalog from "../models/CuratedCatalog.mjs"; // перевіряємо сам імпорт
+import CuratedCatalog, { CuratedCatalog as CuratedCatalogNamed } from "../models/CuratedCatalog.mjs";
+import BambooDump, { BambooDump as BambooDumpNamed } from "../models/BambooDump.mjs";
 
 export const debugRouter = express.Router();
 
 debugRouter.get("/debug/mongoose", async (_req, res) => {
   try {
-    const names = mongoose.modelNames();            // зареєстровані моделі
-    const typeOfModel = typeof CuratedCatalog;      // має бути "function"
-    const protoKeys = CuratedCatalog ? Object.getOwnPropertyNames(CuratedCatalog) : [];
+    const names = mongoose.modelNames();
     res.json({
       ok: true,
-      connected: !!mongoose.connection?.readyState,
+      connected: mongoose.connection?.readyState,
       db: mongoose.connection?.name || null,
       modelNames: names,
       curatedCatalog: {
-        typeof: typeOfModel,
-        hasFindOne: !!CuratedCatalog?.findOne,
-        keys: protoKeys.slice(0, 10),
+        typeofDefault: typeof CuratedCatalog,
+        hasFindOneDefault: !!CuratedCatalog?.findOne,
+        typeofNamed: typeof CuratedCatalogNamed,
+        hasFindOneNamed: !!CuratedCatalogNamed?.findOne,
+      },
+      bambooDump: {
+        typeofDefault: typeof BambooDump,
+        hasUpdateOneDefault: !!BambooDump?.updateOne,
+        typeofNamed: typeof BambooDumpNamed,
+        hasUpdateOneNamed: !!BambooDumpNamed?.updateOne,
       },
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- export CuratedCatalog and BambooDump models as both default and named exports
- expose new `/api/debug/mongoose` endpoint reporting connection and model info
- wire debug router after Mongo connection so it precedes static middleware

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b424593bb8832bbe528d9b8e726fa0