### PR TITLE
refactor: improve mongoose import

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -1,23 +1,43 @@
-import mongoose from "mongoose";
+// src/db/mongoose.mjs
+// Робимо сумісний імпорт для будь-якого бандлінгу (ESM/CJS)
+import * as M from "mongoose";
 
+// Визначаємо реальний інстанс mongoose
+const mg = (M?.default && (M.default.connect || M.default.set))
+  ? M.default
+  : M;
+
+// Сінглтон-флаг підключення
 let connected = false;
 
 export function getMongoose() {
-  return mongoose;
+  return mg;
 }
 
 export async function connectMongo() {
-  if (connected) return mongoose;
+  if (connected) return mg;
+
   const uri = process.env.DB_URL || process.env.MONGODB_URI || process.env.DB_URI;
+  const dbName = process.env.DB_NAME || "Digi";
+
   if (!uri) {
     console.warn("Mongo URI not set (DB_URL / MONGODB_URI / DB_URI). Skipping connect.");
-    return mongoose;
+    return mg;
   }
-  mongoose.set("strictQuery", true);
-  await mongoose.connect(uri, {
-    dbName: process.env.DB_NAME || "Digi",
+
+  // деякі збірки віддають mg без set() — використовуємо опціонально
+  try { mg.set?.("strictQuery", true); } catch {}
+
+  console.log("ℹ️  Mongoose runtime:", {
+    hasConnect: !!mg.connect,
+    hasSet: !!mg.set,
+    version: mg?.version || null,
+    dbName,
   });
+
+  await mg.connect(uri, { dbName });
   connected = true;
-  console.log("✅ Mongo connected:", mongoose.connection?.name || "(unknown)");
-  return mongoose;
+
+  console.log("✅ Mongo connected:", mg.connection?.name || "(unknown)");
+  return mg;
 }

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,5 +1,4 @@
 import { getMongoose } from "../db/mongoose.mjs";
-
 const mongoose = getMongoose();
 
 const CuratedSchema = new mongoose.Schema(
@@ -16,6 +15,5 @@ const CuratedCatalogModel =
   (mongoose.connection?.models?.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
-// подвійний експорт — для сумісності
 export const CuratedCatalog = CuratedCatalogModel;
 export default CuratedCatalogModel;


### PR DESCRIPTION
## Summary
- replace mongoose connection util with bundler-friendly export
- ensure CuratedCatalog model uses shared getMongoose instance
- confirm server connects to Mongo before router registration

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aad4148c832ba1ff4f9347670c71