### PR TITLE
fix mongo connection configuration and logging

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -17,27 +17,31 @@ export function getMongoose() {
 export async function connectMongo() {
   if (connected) return mg;
 
-  const uri = process.env.DB_URL || process.env.MONGODB_URI || process.env.DB_URI;
-  const dbName = process.env.DB_NAME || "Digi";
+  const uri =
+    process.env.DB_URL ||
+    process.env.MONGODB_URI ||
+    process.env.DB_URI;
+
+  // 👇 правильна назва БД: digi (як в Atlas)
+  const dbName = process.env.DB_NAME || "digi";
 
   if (!uri) {
     console.warn("Mongo URI not set (DB_URL / MONGODB_URI / DB_URI). Skipping connect.");
     return mg;
   }
 
-  // деякі збірки віддають mg без set() — використовуємо опціонально
   try { mg.set?.("strictQuery", true); } catch {}
 
-  console.log("ℹ️  Mongoose runtime:", {
-    hasConnect: !!mg.connect,
-    hasSet: !!mg.set,
-    version: mg?.version || null,
-    dbName,
-  });
-
   await mg.connect(uri, { dbName });
+
   connected = true;
 
-  console.log("✅ Mongo connected:", mg.connection?.name || "(unknown)");
+  // 👇 коректне логування імені БД в різних версіях Mongoose/драйвера
+  const name =
+    mg.connection?.name ||
+    mg.connection?.db?.databaseName ||
+    dbName;
+
+  console.log("✅ Mongo connected:", name);
   return mg;
 }


### PR DESCRIPTION
## Summary
- use correct default DB name `digi`
- streamline mongo connection and logging across Mongoose versions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4aefe6080832b97169a1e3966a973