### PR TITLE
Fix Bamboo model exports and router imports

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -39,6 +39,14 @@ app.get("/healthz", (_req, res) => res.json({ ok: true }));
 app.use("/api", bambooExportRouter);
 app.use("/api", curatedRouter);
 
+// далі — основні роутери
+app.use("/api/search", searchRouter);
+app.use("/api/cards", cardsRouter);
+// catalogRouter тепер включає і /api/catalog, і /api/diag/bamboo/*
+app.use("/api", catalogRouter);
+app.use("/api", fxRouter);
+app.use("/api", ordersRouter);
+
 const envDist = process.env.DIST_DIR && path.resolve(process.env.DIST_DIR);
 const candidates = [
   envDist,
@@ -58,14 +66,6 @@ if (found) {
 } else {
   console.error("❌ dist/index.html not found. Ensure build step creates it in the repo root or set DIST_DIR.");
 }
-
-// далі — основні роутери
-app.use("/api/search", searchRouter);
-app.use("/api/cards", cardsRouter);
-// catalogRouter тепер включає і /api/catalog, і /api/diag/bamboo/*
-app.use("/api", catalogRouter);
-app.use("/api", fxRouter);
-app.use("/api", ordersRouter);
 
 app.get("*", (_req, res) => {
   const indexPath = found && path.join(found, "index.html");

--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,24 +1,22 @@
 import { getMongoose } from "../db/mongoose.mjs";
 const mongoose = getMongoose();
 
-/**
- * Зберігаємо "сирий" дамп каталогу (масив брендів з продуктами)
- * ключ — для параметризації дампу (версія/валюти/сортування тощо)
- */
 const DumpSchema = new mongoose.Schema(
   {
     key: { type: String, index: true, unique: true },
     filters: { type: Object, default: {} },
-    rows: { type: Array, default: [] }, // масив брендів з продуктами
+    rows: { type: Array, default: [] },
     updatedAt: { type: Date, default: Date.now },
   },
   { collection: "bamboo_dump" }
 );
 
+// РЕЄСТРАЦІЯ САМОЇ МОДЕЛІ
 const BambooDumpModel =
   mongoose.models?.BambooDump ||
   (mongoose.connection?.models?.BambooDump) ||
   mongoose.model("BambooDump", DumpSchema);
 
-export const BambooDump = BambooDumpModel;
+// ЕКСПОРТУЄМО МОДЕЛЬ (default + named для сумісності)
 export default BambooDumpModel;
+export const BambooDump = BambooDumpModel;

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,17 +1,10 @@
 import { getMongoose } from "../db/mongoose.mjs";
 const mongoose = getMongoose();
 
-/**
- * Кеш по категоріях для фронта
- * key: "gaming" | "streaming" | "shopping" | "music" | "food" | "travel"
- */
 const CuratedSchema = new mongoose.Schema(
   {
     key: { type: String, index: true, unique: true },
-    data: {
-      type: Object,
-      required: true, // { items: [], currencies: [...], counts: {...} }
-    },
+    data: { type: Object, required: true },
     updatedAt: { type: Date, default: Date.now },
   },
   { collection: "curated_catalog" }
@@ -22,5 +15,5 @@ const CuratedCatalogModel =
   (mongoose.connection?.models?.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
-export const CuratedCatalog = CuratedCatalogModel;
 export default CuratedCatalogModel;
+export const CuratedCatalog = CuratedCatalogModel;

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -1,7 +1,7 @@
 import express from "express";
 import { getMongoose } from "../db/mongoose.mjs";
-import CuratedCatalog, { CuratedCatalog as CuratedCatalogNamed } from "../models/CuratedCatalog.mjs";
-import BambooDump, { BambooDump as BambooDumpNamed } from "../models/BambooDump.mjs";
+import CuratedCatalog from "../models/CuratedCatalog.mjs";
+import BambooDump from "../models/BambooDump.mjs";
 
 export const debugRouter = express.Router();
 
@@ -11,6 +11,7 @@ function inspectModel(m) {
     isFunction: typeof m === "function",
     hasFindOne: !!m?.findOne,
     hasUpdateOne: !!m?.updateOne,
+    modelName: m?.modelName || null,
   };
 }
 
@@ -28,8 +29,8 @@ debugRouter.get("/debug/mongoose", (_req, res) => {
         dbName: conn?.name ?? null,
       },
       registeredModels: registered,
-      curatedCatalog: { default: inspectModel(CuratedCatalog), named: inspectModel(CuratedCatalogNamed) },
-      bambooDump: { default: inspectModel(BambooDump), named: inspectModel(BambooDumpNamed) },
+      curatedCatalog: inspectModel(CuratedCatalog),
+      bambooDump: inspectModel(BambooDump),
     });
   } catch (e) {
     res.json({ ok: false, error: e?.message || String(e) });


### PR DESCRIPTION
## Summary
- replace BambooDump and CuratedCatalog models with direct Mongoose model exports
- use default model imports in debug route and expose modelName for inspection
- connect to Mongo before mounting API routes and serve static assets after them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b558c22808832b81f9ad883e20f4b5