### PR TITLE
Connect Mongo before routes and improve debug diagnostics

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2,29 +2,31 @@ import express from "express";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
+
+// Mongo connection must be established before registering routes
 import { connectMongo } from "./src/db/mongoose.mjs";
+
+// Routers and utilities
+import { debugRouter } from "./src/routes/debug.mjs";
+import { diagRouter } from "./src/routes/diag.mjs";
+import { bambooMatrixRouter } from "./src/routes/bamboo-matrix.mjs";
+import { catalogRouter } from "./src/routes/catalog.mjs";
+import cardsRouter from "./routers/cards.js";
+import searchRouter from "./routers/search.js";
+import { bambooExportRouter } from "./src/routes/bamboo-export.mjs";
+import { curatedRouter } from "./src/routes/curated.mjs";
+import * as fxUtils from "./src/utils/fx.mjs";
+import { fxRouter } from "./src/routes/fx.mjs";
+import { ordersRouter } from "./src/orders/router.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
 
-// 1) Конект до Mongo
+// Wait for Mongo to connect before mounting routes
 await connectMongo();
-
-// 2) Тільки тепер підключаємо роутери (які імпортують моделі)
-const { debugRouter } = await import("./src/routes/debug.mjs");
-const { diagRouter } = await import("./src/routes/diag.mjs");
-const { bambooMatrixRouter } = await import("./src/routes/bamboo-matrix.mjs");
-const { catalogRouter } = await import("./src/routes/catalog.mjs");
-const cardsRouter = (await import("./routers/cards.js")).default;
-const searchRouter = (await import("./routers/search.js")).default;
-const { bambooExportRouter } = await import("./src/routes/bamboo-export.mjs");
-const { curatedRouter } = await import("./src/routes/curated.mjs");
-const fxUtils = await import("./src/utils/fx.mjs");
-const { fxRouter } = await import("./src/routes/fx.mjs");
 fxUtils.initFxWatcher?.();
-const { ordersRouter } = await import("./src/orders/router.mjs");
 
 // JSON parser for all /api routes
 app.use("/api", express.json());


### PR DESCRIPTION
## Summary
- Ensure MongoDB connection is established before registering API routes or static handlers
- Replace debug router with explicit mongoose diagnostics and module path inspection
- Confirm BambooDump and CuratedCatalog models export the actual Mongoose model instances

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.mjs`
- `node --check src/routes/debug.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b5714aba14832ba044d87d5543f4fe