### PR TITLE
feat: improve mongo connection and diagnostics

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -1,47 +1,25 @@
-// src/db/mongoose.mjs
-// Робимо сумісний імпорт для будь-якого бандлінгу (ESM/CJS)
-import * as M from "mongoose";
-
-// Визначаємо реальний інстанс mongoose
-const mg = (M?.default && (M.default.connect || M.default.set))
-  ? M.default
-  : M;
-
-// Сінглтон-флаг підключення
-let connected = false;
+import mongoose from "mongoose";
 
 export function getMongoose() {
-  return mg;
+  return mongoose;
 }
 
 export async function connectMongo() {
-  if (connected) return mg;
-
-  const uri =
-    process.env.DB_URL ||
-    process.env.MONGODB_URI ||
-    process.env.DB_URI;
-
-  // 👇 правильна назва БД: digi (як в Atlas)
-  const dbName = process.env.DB_NAME || "digi";
-
+  const uri = process.env.DB_URL;
   if (!uri) {
-    console.warn("Mongo URI not set (DB_URL / MONGODB_URI / DB_URI). Skipping connect.");
-    return mg;
+    console.error("\u274c Mongo URI missing (DB_URL not set)");
+    return;
   }
 
-  try { mg.set?.("strictQuery", true); } catch {}
-
-  await mg.connect(uri, { dbName });
-
-  connected = true;
-
-  // 👇 коректне логування імені БД в різних версіях Mongoose/драйвера
-  const name =
-    mg.connection?.name ||
-    mg.connection?.db?.databaseName ||
-    dbName;
-
-  console.log("✅ Mongo connected:", name);
-  return mg;
+  try {
+    mongoose.set("strictQuery", true);
+    await mongoose.connect(uri);
+    console.log(`\u2705 Mongo connected: ${mongoose.connection.name}`);
+  } catch (err) {
+    console.error("\u274c Mongo connect failed:", err.message || err);
+    throw err;
+  }
 }
+
+export { mongoose };
+


### PR DESCRIPTION
## Summary
- simplify mongoose connection helper with explicit DB_URL usage
- start server even if Mongo fails and add `/api/debug/mongoose` diagnostics

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5c82acbfc832bae6c2ee0d8613306