### PR TITLE
Refactor mongoose setup and models

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,20 +1,38 @@
-import { getMongoose } from "../db/mongoose.mjs";
-const mongoose = getMongoose();
+// src/models/BambooDump.mjs
+import { mongoose } from "../db/mongoose.mjs";
 
-const DumpSchema = new mongoose.Schema(
+const DumpItemSchema = new mongoose.Schema(
   {
-    key: { type: String, index: true, unique: true },
-    filters: { type: Object, default: {} },
-    rows: { type: Array, default: [] },
-    updatedAt: { type: Date, default: Date.now },
+    brandId: Number,
+    brandName: String,
+    productId: Number,
+    productName: String,
+    countryCode: String,
+    currencyCode: String,
+    priceMin: Number,
+    priceMax: Number,
+    raw: Object,             // сирі дані з Bamboo на випадок потреби
   },
-  { collection: "bamboo_dump" }
+  { _id: false }
 );
 
-const BambooDumpModel =
-  mongoose.models?.BambooDump ||
-  (mongoose.connection?.models?.BambooDump) ||
-  mongoose.model("BambooDump", DumpSchema);
+const BambooDumpSchema = new mongoose.Schema(
+  {
+    key: { type: String, required: true, unique: true, index: true }, // наприклад "catalog:v2:page:0"
+    pageIndex: { type: Number, default: 0 },
+    pageSize: { type: Number, default: 100 },
+    count: { type: Number, default: 0 },
+    items: [DumpItemSchema],
+    fetchedAt: { type: Date, default: Date.now },
+    meta: { type: Object },
+  },
+  { timestamps: true }
+);
 
-export default BambooDumpModel;
-export const BambooDump = BambooDumpModel;
+// ЕКСПОРТУЄМО САМЕ МОДЕЛЬ!
+export const BambooDump =
+  mongoose.models.BambooDump ||
+  mongoose.model("BambooDump", BambooDumpSchema);
+
+export default BambooDump;
+

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,19 +1,54 @@
-import { getMongoose } from "../db/mongoose.mjs";
-const mongoose = getMongoose();
+// src/models/CuratedCatalog.mjs
+import { mongoose } from "../db/mongoose.mjs";
+
+const PriceSchema = new mongoose.Schema(
+  {
+    currency: { type: String, required: true },   // USD/EUR/...
+    amount: { type: Number, required: true },     // з маркапом/без — як зручно
+  },
+  { _id: false }
+);
+
+const ProductSchema = new mongoose.Schema(
+  {
+    productId: { type: Number, required: true },
+    name: { type: String, required: true },
+    countryCode: { type: String },               // US/DE/...
+    currencyCode: { type: String },              // базова валюта товару
+    logoUrl: { type: String },
+    prices: [PriceSchema],                        // перераховані валюти
+    raw: { type: Object },                        // ориг дані з Bamboo (на всяк)
+  },
+  { _id: false }
+);
+
+const CategorySchema = new mongoose.Schema(
+  {
+    key: { type: String, required: true },        // gaming / streaming / shopping / music / food / travel ...
+    brands: [
+      {
+        brand: { type: String, required: true },  // Playstation / Xbox / Steam / Nintendo / ...
+        items: [ProductSchema],
+      },
+    ],
+  },
+  { _id: false }
+);
 
 const CuratedSchema = new mongoose.Schema(
   {
-    key: { type: String, index: true, unique: true },
-    data: { type: Object, required: true },
+    slug: { type: String, default: "default", unique: true, index: true },
+    currencies: [{ type: String }],               // наприклад ["USD","EUR","CAD","AUD"]
+    categories: [CategorySchema],
     updatedAt: { type: Date, default: Date.now },
   },
-  { collection: "curated_catalog" }
+  { timestamps: true }
 );
 
-const CuratedCatalogModel =
-  mongoose.models?.CuratedCatalog ||
-  (mongoose.connection?.models?.CuratedCatalog) ||
+// ЕКСПОРТУЄМО САМЕ МОДЕЛЬ!
+export const CuratedCatalog =
+  mongoose.models.CuratedCatalog ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
-export default CuratedCatalogModel;
-export const CuratedCatalog = CuratedCatalogModel;
+export default CuratedCatalog;
+

--- a/src/models/Order.mjs
+++ b/src/models/Order.mjs
@@ -1,6 +1,4 @@
-import { getMongoose } from "../db/mongoose.mjs";
-
-const mongoose = getMongoose();
+import { mongoose } from "../db/mongoose.mjs";
 
 const LineSchema = new mongoose.Schema({
   productId: String,
@@ -32,10 +30,9 @@ const OrderSchema = new mongoose.Schema(
   { collection: "orders" }
 );
 
-const OrderModel =
-  mongoose.models?.Order ||
-  (mongoose.connection?.models?.Order) ||
+export const Order =
+  mongoose.models.Order ||
   mongoose.model("Order", OrderSchema);
 
-export const Order = OrderModel;
-export default OrderModel;
+export default Order;
+

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -1,5 +1,5 @@
 import express from "express";
-import { getMongoose } from "../db/mongoose.mjs";
+import { mongoose } from "../db/mongoose.mjs";
 import CuratedCatalog from "../models/CuratedCatalog.mjs";
 import BambooDump from "../models/BambooDump.mjs";
 
@@ -17,7 +17,7 @@ function inspectModel(m) {
 
 debugRouter.get("/debug/mongoose", (_req, res) => {
   try {
-    const mg = getMongoose();
+    const mg = mongoose;
     const conn = mg.connection || null;
     const registered = Object.keys(conn?.models || mg.models || {});
     res.json({
@@ -39,3 +39,5 @@ debugRouter.get("/debug/mongoose", (_req, res) => {
 });
 
 debugRouter.get("/debug/ping", (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
+
+export default debugRouter;

--- a/src/utils/db.mjs
+++ b/src/utils/db.mjs
@@ -1,8 +1,8 @@
-import { connectMongo, getMongoose } from "../db/mongoose.mjs";
+import { connectMongo, mongoose } from "../db/mongoose.mjs";
 
 export { connectMongo };
 
 export function mongoReady() {
-  const mongoose = getMongoose();
   return mongoose.connection?.readyState === 1;
 }
+


### PR DESCRIPTION
## Summary
- replace mongoose connector with singleton implementation
- export real CuratedCatalog and BambooDump models
- align Order model and utilities with new mongoose export
- update debug utilities to inspect models

## Testing
- `curl -s http://localhost:10000/api/health`
- `curl -s http://localhost:10000/api/bamboo/export.json`
- `curl -s http://localhost:10000/api/curated/gaming`


------
https://chatgpt.com/codex/tasks/task_e_68b68e079428832bab1af7c11061d669