### PR TITLE
fix: unify mongoose instance and harden model imports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 PORT=10000
-DB_URL=mongodb+srv://digi_user:<pass>@digi.fwbova3.mongodb.net/Digi?retryWrites=true&w=majority&appName=Digi
-MONGODB_DB_NAME=Digi
+DB_URL=mongodb+srv://digi_user:<pass>@digi.fwbova3.mongodb.net/?retryWrites=true&w=majority&appName=Digi
+DB_NAME=Digi
 API_KEY=your_api_key_here
 VITE_API_BASE=https://digi-backend-ln8f.onrender.com/api
 

--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,5 +1,11 @@
 // src/models/BambooDump.mjs
-import mongoose from "../db/mongoose.mjs";
+import * as mg from "../db/mongoose.mjs";
+
+const mongoose = mg.default || mg.mongoose || mg;
+if (!mongoose || typeof mongoose.Schema !== "function") {
+  throw new Error("Mongoose import failed in BambooDump.mjs");
+}
+if (!mongoose.models) mongoose.models = {};
 
 const DumpItemSchema = new mongoose.Schema(
   {
@@ -35,4 +41,3 @@ const BambooDump =
 
 export default BambooDump;
 export { BambooDump };
-

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,5 +1,14 @@
 // src/models/CuratedCatalog.mjs
-import mongoose from "../db/mongoose.mjs";
+import * as mg from "../db/mongoose.mjs";
+
+// Ultra-robust way to get the singleton mongoose
+const mongoose = mg.default || mg.mongoose || mg;
+if (!mongoose || typeof mongoose.Schema !== "function") {
+  throw new Error("Mongoose import failed in CuratedCatalog.mjs");
+}
+
+// defensive: make sure models map exists
+if (!mongoose.models) mongoose.models = {};
 
 const PriceSchema = new mongoose.Schema(
   { currency: String, amount: Number },
@@ -21,10 +30,10 @@ const ProductSchema = new mongoose.Schema(
 
 const CategorySchema = new mongoose.Schema(
   {
-    key: { type: String, required: true },
+    key: { type: String, required: true }, // gaming / streaming / shopping / music / food / travel ...
     brands: [
       {
-        brand: { type: String, required: true },
+        brand: { type: String, required: true }, // Playstation / Xbox / Steam / Nintendo / ...
         items: [ProductSchema],
       },
     ],
@@ -48,4 +57,3 @@ const CuratedCatalog =
 
 export default CuratedCatalog;
 export { CuratedCatalog };
-


### PR DESCRIPTION
## Summary
- ensure global mongoose singleton with connect helper
- load CuratedCatalog and BambooDump with defensive mongoose import
- document DB_NAME env var

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "import('./src/models/CuratedCatalog.mjs').then(m=>console.log('Curated ok', Object.keys(m))).catch(e=>console.error(e))"`
- `node -e "import('./src/models/BambooDump.mjs').then(m=>console.log('Bamboo ok', Object.keys(m))).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_68b69868fa80832ba601164667c8ea1c