### PR TITLE
Warm up models and enhance debug route

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -17,6 +17,8 @@ app.get("/api/health", (_req, res) => res.json({ ok: true, ts: new Date().toISOS
 // 1) Спочатку БД
 await connectMongo();
 
+await import("./src/models/index.mjs"); // прогріваємо/реєструємо моделі у singleton
+
 // 2) Потім динамічно роутери (щоб моделі піднялись на вже підключеному інстансі)
 const { debugRouter } = await import("./src/routes/debug.mjs");
 app.use("/api", debugRouter);

--- a/src/models/index.mjs
+++ b/src/models/index.mjs
@@ -1,0 +1,7 @@
+// src/models/index.mjs
+// Імпортуємо моделі для side-effect, щоби вони зареєструвались у mongoose.models
+import "./CuratedCatalog.mjs";
+import "./BambooDump.mjs";
+
+// опціонально: експорт назв — корисно для дебагу
+export default ["CuratedCatalog", "BambooDump"];


### PR DESCRIPTION
## Summary
- register CuratedCatalog and BambooDump models on startup
- pre-load models after connecting to MongoDB
- revamp debug route to report mongoose state from singleton

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6a2bf28bc832bbae276f71cc56b23