### PR TITLE
refactor: convert catalogs to mongoose models

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,37 +1,26 @@
 // src/models/BambooDump.mjs
 import * as mg from "../db/mongoose.mjs";
 const mongoose = mg.default || mg.mongoose || mg;
+
 if (!mongoose || typeof mongoose.Schema !== "function") {
-  throw new Error("Mongoose import failed");
+  throw new Error("Mongoose import failed in BambooDump.mjs");
 }
 if (!mongoose.models) mongoose.models = {};
 
-const DumpItemSchema = new mongoose.Schema(
-  {
-    brandId: Number,
-    brandName: String,
-    productId: Number,
-    productName: String,
-    countryCode: String,
-    currencyCode: String,
-    priceMin: Number,
-    priceMax: Number,
-    raw: Object,
-  },
-  { _id: false }
-);
-
 const BambooDumpSchema = new mongoose.Schema(
   {
-    key: { type: String, required: true, unique: true, index: true },
-    pageIndex: { type: Number, default: 0 },
-    pageSize: { type: Number, default: 100 },
-    count: { type: Number, default: 0 },
-    items: [DumpItemSchema],
-    fetchedAt: { type: Date, default: Date.now },
-    meta: Object,
+    // параметри запиту до каталогу, щоб ідентифікувати дамп
+    query: { type: Object, default: {} },
+
+    // сира відповідь (список сторінок / brands / products)
+    items: { type: Array, default: [] },
+
+    // службові
+    pagesFetched: { type: Number, default: 0 },
+    total: { type: Number, default: 0 },
+    updatedAt: { type: Date, default: Date.now },
   },
-  { timestamps: true, collection: "bamboo_dump" }
+  { collection: "bamboo_dump" } // ФІКСУЄМО назву колекції
 );
 
 const BambooDump =
@@ -39,4 +28,3 @@ const BambooDump =
   mongoose.model("BambooDump", BambooDumpSchema);
 
 export default BambooDump;
-export { BambooDump };

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,56 +1,35 @@
 // src/models/CuratedCatalog.mjs
 import * as mg from "../db/mongoose.mjs";
 const mongoose = mg.default || mg.mongoose || mg;
+
 if (!mongoose || typeof mongoose.Schema !== "function") {
-  throw new Error("Mongoose import failed");
+  throw new Error("Mongoose import failed in CuratedCatalog.mjs");
 }
 if (!mongoose.models) mongoose.models = {};
 
-
-const PriceSchema = new mongoose.Schema(
-  { currency: String, amount: Number },
-  { _id: false }
-);
-
-const ProductSchema = new mongoose.Schema(
-  {
-    productId: { type: Number, required: true },
-    name: { type: String, required: true },
-    countryCode: String,
-    currencyCode: String,
-    logoUrl: String,
-    prices: [PriceSchema],
-    raw: Object,
-  },
-  { _id: false }
-);
-
-const CategorySchema = new mongoose.Schema(
-  {
-    key: { type: String, required: true }, // gaming / streaming / shopping / music / food / travel ...
-    brands: [
-      {
-        brand: { type: String, required: true }, // Playstation / Xbox / Steam / Nintendo / ...
-        items: [ProductSchema],
-      },
-    ],
-  },
-  { _id: false }
-);
-
 const CuratedSchema = new mongoose.Schema(
   {
-    slug: { type: String, default: "default", unique: true, index: true },
-    currencies: [String],
-    categories: [CategorySchema],
+    // ключ кешу (категорія/валюти тощо)
+    key: { type: String, required: true, index: true, unique: true },
+
+    // масив товарів, що показуємо на фронті
+    items: { type: Array, default: [] },
+
+    // метадані побудови
+    currencies: { type: [String], default: [] },
+    groups: { type: Object, default: {} }, // gaming/streaming/shopping/... -> масиви
     updatedAt: { type: Date, default: Date.now },
+    source: {
+      bambooPages: { type: Number, default: 0 },
+      bambooCount: { type: Number, default: 0 },
+    },
   },
-  { timestamps: true, collection: "curated_catalog" }
+  { collection: "curated_catalog" } // ФІКСУЄМО назву колекції
 );
 
+// реєструємо МОДЕЛЬ (оце і додає її в mongoose.modelNames())
 const CuratedCatalog =
   mongoose.models.CuratedCatalog ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
 export default CuratedCatalog;
-export { CuratedCatalog };


### PR DESCRIPTION
## Summary
- replace `CuratedCatalog` with proper Mongoose model and explicit collection
- replace `BambooDump` with proper Mongoose model and explicit collection

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6d9fb04d4832bb32c09d1e6bfeda7