### PR TITLE
feat: unify mongoose models

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1,3 +1,4 @@
+// server.mjs
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -6,59 +7,53 @@ import { connectMongo } from "./src/db/mongoose.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 
-// JSON + urlencoded
-app.use(express.json({ limit: "1mb" }));
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 
-// 1) Connect to Mongo FIRST
-await connectMongo();
-
-// 2) Warm up mongoose models BEFORE routes
-const modelIndex = await import("./src/models/index.mjs");
-if (modelIndex?.default) {
-  console.log("🧩 Models registered:", modelIndex.default.join(", "));
-}
-
-// 3) Only now import and mount routes (all routers import models safely)
-const { debugRouter } = await import("./src/routes/debug.mjs");
-app.use("/api", debugRouter);
-
-// mount your other routers AFTER debug if needed
-// e.g.
-// const { bambooRouter } = await import("./src/routers/bamboo.js");
-// app.use("/api", bambooRouter);
-
-// static
+// Статика (Vite build)
 const distCandidates = [
   path.join(__dirname, "dist"),
   path.join(__dirname, "frontend", "dist"),
-  path.join(__dirname, "client", "dist"),
+  path.join(__dirname, "client", "dist")
 ];
 
 let served = false;
 for (const p of distCandidates) {
   try {
-    const ok = await fsExists(p);
-    console.log(`🔎 DIST candidate: ${p} exists: ${ok}`);
-    if (ok && !served) {
+    const exists = await (async () => {
+      try { return (await import("node:fs/promises")).stat(p).then(s => s.isDirectory()).catch(() => false); } catch { return false; }
+    })();
+    console.log(`🔎 DIST candidate: ${p} exists: ${exists}`);
+    if (exists && !served) {
       app.use(express.static(p));
-      console.log("✅ Serving static from:", p);
+      console.log(`✅ Serving static from: ${p}`);
       served = true;
     }
-  } catch {
-    console.log(`🔎 DIST candidate: ${p} exists: false`);
-  }
+  } catch {}
 }
-if (!served) console.warn("⚠️  No static dist folder found");
 
-// start
 const PORT = process.env.PORT || 10000;
-app.listen(PORT, () => {
-  console.log(`Server on :${PORT}`);
-});
 
-// small helper
-async function fsExists(p) {
-  const { access } = await import("node:fs/promises");
-  try { await access(p); return true; } catch { return false; }
-}
+// Старт з'єднання і роутів
+(async () => {
+  try {
+    await connectMongo();
+
+    // ІМПОРТИ РОУТІВ ПІСЛЯ КОНЕКТУ
+    const { debugRouter } = await import("./src/routes/debug.mjs");
+    app.use("/api/debug", debugRouter);
+
+    // інші роутери:
+    // const { bambooRouter } = await import("./src/routes/bamboo.mjs");
+    // const { curatedRouter } = await import("./src/routes/curated.mjs");
+    // app.use("/api/bamboo", bambooRouter);
+    // app.use("/api/curated", curatedRouter);
+
+    app.listen(PORT, () => {
+      console.log(`Server on :${PORT}`);
+    });
+  } catch (err) {
+    console.error("❌ Startup failed:", err?.message || err);
+    process.exit(1);
+  }
+})();
+

--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,30 +1,35 @@
 // src/models/BambooDump.mjs
-import * as mg from "../db/mongoose.mjs";
-const mongoose = mg.default || mg.mongoose || mg;
+import { getMongoose } from "../db/mongoose.mjs";
 
-if (!mongoose || typeof mongoose.Schema !== "function") {
-  throw new Error("Mongoose import failed in BambooDump.mjs");
-}
-if (!mongoose.models) mongoose.models = {};
+const mongoose = getMongoose();
+
+const BambooProductSchema = new mongoose.Schema(
+  {
+    id: { type: Number, index: true },
+    name: String,
+    brand: String,
+    countryCode: String,
+    currencyCode: String,
+    priceMin: Number,
+    priceMax: Number,
+    modifiedDate: Date,
+    raw: {}
+  },
+  { _id: false }
+);
 
 const BambooDumpSchema = new mongoose.Schema(
   {
-    // параметри запиту до каталогу, щоб ідентифікувати дамп
-    query: { type: Object, default: {} },
-
-    // сира відповідь (список сторінок / brands / products)
-    items: { type: Array, default: [] },
-
-    // службові
-    pagesFetched: { type: Number, default: 0 },
-    total: { type: Number, default: 0 },
-    updatedAt: { type: Date, default: Date.now },
+    page: { type: Number, index: true },
+    pageSize: Number,
+    count: Number,
+    fetchedAt: { type: Date, default: Date.now, index: true },
+    products: [BambooProductSchema]
   },
-  { collection: "bamboo_dump" } // ФІКСУЄМО назву колекції
+  { collection: "bamboo_dump" }
 );
 
-const BambooDump =
-  mongoose.models.BambooDump ||
+export const BambooDump =
+  (mongoose.models && mongoose.models.BambooDump) ||
   mongoose.model("BambooDump", BambooDumpSchema);
 
-export default BambooDump;

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,35 +1,32 @@
 // src/models/CuratedCatalog.mjs
-import * as mg from "../db/mongoose.mjs";
-const mongoose = mg.default || mg.mongoose || mg;
+import { getMongoose } from "../db/mongoose.mjs";
 
-if (!mongoose || typeof mongoose.Schema !== "function") {
-  throw new Error("Mongoose import failed in CuratedCatalog.mjs");
-}
-if (!mongoose.models) mongoose.models = {};
+const mongoose = getMongoose();
+
+const CuratedItemSchema = new mongoose.Schema(
+  {
+    productId: { type: Number, index: true },
+    name: String,
+    brand: String,
+    countryCode: String,
+    currencyCode: String,
+    price: Number,
+    logos: [String],
+    raw: {} // повний сирий bamboo item
+  },
+  { _id: false }
+);
 
 const CuratedSchema = new mongoose.Schema(
   {
-    // ключ кешу (категорія/валюти тощо)
-    key: { type: String, required: true, index: true, unique: true },
-
-    // масив товарів, що показуємо на фронті
-    items: { type: Array, default: [] },
-
-    // метадані побудови
-    currencies: { type: [String], default: [] },
-    groups: { type: Object, default: {} }, // gaming/streaming/shopping/... -> масиви
-    updatedAt: { type: Date, default: Date.now },
-    source: {
-      bambooPages: { type: Number, default: 0 },
-      bambooCount: { type: Number, default: 0 },
-    },
+    key: { type: String, required: true, unique: true }, // наприклад "gaming"
+    updatedAt: { type: Date, default: Date.now, index: true },
+    items: [CuratedItemSchema]
   },
-  { collection: "curated_catalog" } // ФІКСУЄМО назву колекції
+  { collection: "curated_catalog" }
 );
 
-// реєструємо МОДЕЛЬ (оце і додає її в mongoose.modelNames())
-const CuratedCatalog =
-  mongoose.models.CuratedCatalog ||
+export const CuratedCatalog =
+  (mongoose.models && mongoose.models.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 
-export default CuratedCatalog;


### PR DESCRIPTION
## Summary
- ensure MongoDB connection is established once and shared across routers
- rework model definitions for CuratedCatalog and BambooDump
- add debug endpoints to inspect registered models and connection

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6ef068d28832baa7b5d7a3be7366a