### PR TITLE
Ensure single mongoose instance and proper model registration

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,7 +1,5 @@
 // src/models/BambooDump.mjs
-import { getMongoose } from "../db/mongoose.mjs";
-
-const mongoose = getMongoose();
+import { mongoose } from "../db/mongoose.mjs";
 
 const BambooProductSchema = new mongoose.Schema(
   {
@@ -30,6 +28,6 @@ const BambooDumpSchema = new mongoose.Schema(
 );
 
 export const BambooDump =
-  (mongoose.models && mongoose.models.BambooDump) ||
+  (mongoose.models?.BambooDump) ||
   mongoose.model("BambooDump", BambooDumpSchema);
 

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,7 +1,5 @@
 // src/models/CuratedCatalog.mjs
-import { getMongoose } from "../db/mongoose.mjs";
-
-const mongoose = getMongoose();
+import { mongoose } from "../db/mongoose.mjs";
 
 const CuratedItemSchema = new mongoose.Schema(
   {
@@ -27,6 +25,6 @@ const CuratedSchema = new mongoose.Schema(
 );
 
 export const CuratedCatalog =
-  (mongoose.models && mongoose.models.CuratedCatalog) ||
+  (mongoose.models?.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
 

--- a/src/models/Order.mjs
+++ b/src/models/Order.mjs
@@ -1,4 +1,4 @@
-import mongoose from "../db/mongoose.mjs";
+import { mongoose } from "../db/mongoose.mjs";
 
 const LineSchema = new mongoose.Schema({
   productId: String,

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -1,6 +1,6 @@
 // src/routes/debug.mjs
 import express from "express";
-import { getMongoose } from "../db/mongoose.mjs";
+import { mongoose } from "../db/mongoose.mjs";
 
 export const debugRouter = express.Router();
 
@@ -9,39 +9,29 @@ debugRouter.get("/ping", (_, res) => {
 });
 
 debugRouter.get("/wire", async (_req, res) => {
-  const m1 = getMongoose();
+  const m1 = mongoose;
   const m2 = (await import("mongoose")).default;
   res.json({
     ok: true,
     sameInstance: m1 === m2,
     version: m1?.version ?? null,
     readyState: m1?.connection?.readyState ?? null,
-    modelNames:
-      typeof m1.modelNames === "function" ? m1.modelNames() : []
+    modelNames: typeof m1.modelNames === "function" ? m1.modelNames() : []
   });
 });
 
 debugRouter.get("/mongoose", (_req, res) => {
-  const mongoose = getMongoose();
-  const names =
-    typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [];
+  const names = typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [];
   res.json({
     ok: true,
     runtime: {
       connectionReadyState: mongoose.connection?.readyState ?? null,
-      dbName:
-        mongoose.connection?.name ??
-        mongoose.connections?.[0]?.name ??
-        null,
-      version: mongoose.version ?? null
+      dbName: mongoose.connection?.name ?? null,
+      version: mongoose?.version ?? null,
+      modelNames: names,
     },
-    modelNames: names,
-    curatedCatalog: {
-      registered: !!names.includes("CuratedCatalog")
-    },
-    bambooDump: {
-      registered: !!names.includes("BambooDump")
-    }
+    curatedCatalog: { registered: Boolean(mongoose.models?.CuratedCatalog) },
+    bambooDump: { registered: Boolean(mongoose.models?.BambooDump) },
   });
 });
 

--- a/src/utils/db.mjs
+++ b/src/utils/db.mjs
@@ -1,4 +1,4 @@
-import mongoose, { connectMongo } from "../db/mongoose.mjs";
+import { mongoose, connectMongo } from "../db/mongoose.mjs";
 
 export { connectMongo };
 


### PR DESCRIPTION
## Summary
- centralize mongoose connection and guard against multiple connections
- load models and routes after connecting, logging registered models
- expose model list via /api/debug/mongoose

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd36e2c284832b871430c99d72db54