### PR TITLE
Ensure single mongoose instance and register models

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -35,36 +35,30 @@ const PORT = process.env.PORT || 10000;
 
 // Старт з'єднання і роутів
 async function bootstrap() {
-  try {
-    await connectMongo();
+  await connectMongo();
 
-    // Реєструємо моделі після підключення
-    const { CuratedCatalog } = await import("./src/models/CuratedCatalog.mjs");
-    const { BambooDump } = await import("./src/models/BambooDump.mjs");
+  // РЕЄСТРУЄМО моделі ПІСЛЯ конекту і з нашою інстанцією
+  await import("./src/models/CuratedCatalog.mjs");
+  await import("./src/models/BambooDump.mjs");
 
-    // Імпортуємо роутери
-    const { debugRouter } = await import("./src/routes/debug.mjs");
-    const { bambooRouter } = await import("./src/routes/bamboo.mjs");
-    const { curatedRouter } = await import("./src/routes/curated.mjs");
-    app.use("/api/debug", debugRouter);
-    app.use("/api/bamboo", bambooRouter);
-    app.use("/api/curated", curatedRouter);
+  // Імпортуємо роутери
+  const { debugRouter } = await import("./src/routes/debug.mjs");
+  const { bambooRouter } = await import("./src/routes/bamboo.mjs");
+  const { curatedRouter } = await import("./src/routes/curated.mjs");
+  app.use("/api/debug", debugRouter);
+  app.use("/api/bamboo", bambooRouter);
+  app.use("/api/curated", curatedRouter);
 
-    const modelNames =
-      typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [];
-    console.log("\uD83E\uDDE9 Models registered:", modelNames.join(", ") || "[]");
+  const names = typeof mongoose.modelNames === 'function' ? mongoose.modelNames() : [];
+  console.log('🧩 Models registered:', names.join(', ') || '[]');
 
-    app.listen(PORT, () => {
-      console.log(`Server on :${PORT}`);
-    });
-  } catch (err) {
-    console.error("❌ Startup failed:", err?.message || err);
-    process.exit(1);
-  }
+  app.listen(PORT, () => {
+    console.log(`Server on :${PORT}`);
+  });
 }
 
-bootstrap().catch((e) => {
-  console.error("❌ Bootstrap failed:", e?.message || e);
+bootstrap().catch(err => {
+  console.error('❌ Bootstrap failed:', err?.message || err);
   process.exit(1);
 });
 

--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -1,38 +1,22 @@
 // src/db/mongoose.mjs
-import _mongoose from "mongoose";
+import _mongoose from 'mongoose';
 
-// ЄДИНА інстанція mongoose, яку використовують всі моделі
-export const mongoose = _mongoose;
+// --- GLOBAL SINGLETON (щоб ВСІ файли отримували ту саму інстанцію)
+if (!globalThis.__DG_MONGOOSE__) {
+  globalThis.__DG_MONGOOSE__ = { mongoose: _mongoose, connected: false };
+}
+export const mongoose = globalThis.__DG_MONGOOSE__.mongoose;
 
-/**
- * Підключення до MongoDB та повернення інстансу mongoose.
- * Викликається один раз під час старту серверу.
- */
 export async function connectMongo() {
-  // Страхуємося від подвійного set у деяких оточеннях
-  try {
-    mongoose.set("strictQuery", true);
-  } catch {}
-
   const uri = process.env.DB_URL || process.env.MONGODB_URI;
-  const dbName = process.env.DB_NAME || "digi";
-  if (!uri) throw new Error("DB_URL/MONGODB_URI is not set");
-
-  // Якщо вже підключені – повертаємо існуючий інстанс
-  if (mongoose.connection?.readyState === 1) return mongoose;
-
-  const conn = await mongoose.connect(uri, { dbName });
-
-  const name =
-    conn.connection?.name ||
-    conn.connections?.[0]?.name ||
-    dbName;
-  console.log(`Mongo connected: ${name}`);
+  const dbName = process.env.DB_NAME || 'digi';
+  if (!uri) throw new Error('DB_URL/MONGODB_URI is not set');
+  if (!globalThis.__DG_MONGOOSE__.connected) {
+    try { mongoose.set('strictQuery', true); } catch {}
+    await mongoose.connect(uri, { dbName });
+    globalThis.__DG_MONGOOSE__.connected = true;
+    const name = mongoose.connection?.name || dbName;
+    console.log(`Mongo connected: ${name}`);
+  }
   return mongoose;
 }
-
-// Зворотна сумісність – деякі старі модулі могли викликати getMongoose
-export function getMongoose() {
-  return mongoose;
-}
-


### PR DESCRIPTION
## Summary
- centralize mongoose into a global singleton to avoid multiple connections
- bootstrap connects to Mongo and dynamically loads models before routers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0452d528832ba87e32d9ebc575ca