### PR TITLE
Ensure mongoose models register with singleton

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -35,21 +35,21 @@ const PORT = process.env.PORT || 10000;
 
 // Старт з'єднання і роутів
 async function bootstrap() {
-  await connectMongo();
+  const m = await connectMongo();
 
   // РЕЄСТРУЄМО моделі ПІСЛЯ конекту і з нашою інстанцією
-  await import("./src/models/CuratedCatalog.mjs");
-  await import("./src/models/BambooDump.mjs");
+  await import(new URL("./src/models/CuratedCatalog.mjs", import.meta.url));
+  await import(new URL("./src/models/BambooDump.mjs", import.meta.url));
 
   // Імпортуємо роутери
-  const { debugRouter } = await import("./src/routes/debug.mjs");
+  const debugRouter = (await import(new URL("./src/routes/debug.mjs", import.meta.url))).default;
   const { bambooRouter } = await import("./src/routes/bamboo.mjs");
   const { curatedRouter } = await import("./src/routes/curated.mjs");
   app.use("/api/debug", debugRouter);
   app.use("/api/bamboo", bambooRouter);
   app.use("/api/curated", curatedRouter);
 
-  const names = typeof mongoose.modelNames === 'function' ? mongoose.modelNames() : [];
+  const names = typeof m.modelNames === 'function' ? m.modelNames() : [];
   console.log('🧩 Models registered:', names.join(', ') || '[]');
 
   app.listen(PORT, () => {

--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -1,8 +1,9 @@
 // src/db/mongoose.mjs
-import _mongoose from 'mongoose';
 
 // --- GLOBAL SINGLETON (щоб ВСІ файли отримували ту саму інстанцію)
 if (!globalThis.__DG_MONGOOSE__) {
+  // динамічний імпорт гарантує єдину інстанцію mongoose у всьому застосунку
+  const _mongoose = (await import('mongoose')).default ?? (await import('mongoose'));
   globalThis.__DG_MONGOOSE__ = { mongoose: _mongoose, connected: false };
 }
 export const mongoose = globalThis.__DG_MONGOOSE__.mongoose;
@@ -12,7 +13,7 @@ export async function connectMongo() {
   const dbName = process.env.DB_NAME || 'digi';
   if (!uri) throw new Error('DB_URL/MONGODB_URI is not set');
   if (!globalThis.__DG_MONGOOSE__.connected) {
-    try { mongoose.set('strictQuery', true); } catch {}
+    try { mongoose.set?.('strictQuery', true); } catch {}
     await mongoose.connect(uri, { dbName });
     globalThis.__DG_MONGOOSE__.connected = true;
     const name = mongoose.connection?.name || dbName;

--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -30,4 +30,5 @@ const BambooDumpSchema = new mongoose.Schema(
 export const BambooDump =
   (mongoose.models?.BambooDump) ||
   mongoose.model("BambooDump", BambooDumpSchema);
+console.log('[model] BambooDump registered');
 

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -27,4 +27,5 @@ const CuratedSchema = new mongoose.Schema(
 export const CuratedCatalog =
   (mongoose.models?.CuratedCatalog) ||
   mongoose.model("CuratedCatalog", CuratedSchema);
+console.log('[model] CuratedCatalog registered');
 


### PR DESCRIPTION
## Summary
- enforce a single mongoose instance and connection helper
- register CuratedCatalog and BambooDump after Mongo connect and log results
- add debug routes for inspecting mongoose state and hot-reloading models

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e 'import("./src/routes/debug.mjs").then(m=>console.log("loaded", !!m.default)).catch(e=>console.error(e))'`


------
https://chatgpt.com/codex/tasks/task_e_68c0065c846c832b9334c9c81314afbe