### PR TITLE
Ensure Mongoose models register and debug endpoint lists them

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -37,10 +37,6 @@ const PORT = process.env.PORT || 10000;
 async function bootstrap() {
   await connectMongo();
 
-  // РЕЄСТРУЄМО моделі ПІСЛЯ конекту і з нашою інстанцією
-  await import("./src/models/CuratedCatalog.mjs");
-  await import("./src/models/BambooDump.mjs");
-
   // Імпортуємо роутери
   const { debugRouter } = await import("./src/routes/debug.mjs");
   const { bambooRouter } = await import("./src/routes/bamboo.mjs");

--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -17,6 +17,12 @@ export async function connectMongo() {
     globalThis.__DG_MONGOOSE__.connected = true;
     const name = mongoose.connection?.name || dbName;
     console.log(`Mongo connected: ${name}`);
+    // Ensure all models are registered with this mongoose instance
+    try {
+      await import("../models/index.mjs");
+    } catch (err) {
+      console.error('Failed to register models:', err?.message || err);
+    }
   }
   return mongoose;
 }

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -20,7 +20,11 @@ debugRouter.get("/wire", async (_req, res) => {
   });
 });
 
-debugRouter.get("/mongoose", (_req, res) => {
+debugRouter.get("/mongoose", async (_req, res) => {
+  // Ensure models are registered before listing names
+  try {
+    await import("../models/index.mjs");
+  } catch {}
   const names = typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [];
   res.json({
     ok: true,


### PR DESCRIPTION
## Summary
- Register all models automatically after establishing the Mongo connection
- Load models in `/api/debug/mongoose` before returning names

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c046f5e2a0832bbc4bc6d0cce65539