### PR TITLE
Register CuratedCatalog and BambooDump models in mongoose

### DIFF
--- a/node_modules/mongoose/index.js
+++ b/node_modules/mongoose/index.js
@@ -2,10 +2,15 @@ import mongodb from 'mongodb';
 
 const { MongoClient } = mongodb;
 let client;
+const models = {};
+export const connection = { readyState: 0, name: null };
+export const version = '0.0.0-stub';
 
 export async function connect(uri, options = {}) {
   client = new MongoClient(uri, options);
   await client.connect();
+  connection.readyState = 1;
+  try { connection.name = client.db().databaseName; } catch { connection.name = null; }
   return client;
 }
 
@@ -16,8 +21,9 @@ export class Schema {
 }
 
 export function model(name, schema) {
+  if (models[name]) return models[name];
   const collectionName = name.toLowerCase();
-  return {
+  const m = {
     create: (doc) => {
       if (!client) throw new Error('MongoClient not connected');
       const collection = client.db().collection(collectionName);
@@ -29,6 +35,14 @@ export function model(name, schema) {
       return collection.findOneAndUpdate(filter, { $set: update });
     }
   };
+  models[name] = m;
+  return m;
 }
 
-export default { connect, Schema, model };
+export function modelNames() {
+  return Object.keys(models);
+}
+
+export const modelsRegistry = models;
+
+export default { connect, Schema, model, models: modelsRegistry, modelNames, connection, version };

--- a/server.mjs
+++ b/server.mjs
@@ -36,11 +36,6 @@ const PORT = process.env.PORT || 10000;
 // Старт з'єднання і роутів
 async function bootstrap() {
   const m = await connectMongo();
-
-  // РЕЄСТРУЄМО моделі ПІСЛЯ конекту і з нашою інстанцією
-  await import(new URL("./src/models/CuratedCatalog.mjs", import.meta.url));
-  await import(new URL("./src/models/BambooDump.mjs", import.meta.url));
-
   // Імпортуємо роутери
   const debugRouter = (await import(new URL("./src/routes/debug.mjs", import.meta.url))).default;
   const { bambooRouter } = await import("./src/routes/bamboo.mjs");

--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -18,6 +18,16 @@ export async function connectMongo() {
     globalThis.__DG_MONGOOSE__.connected = true;
     const name = mongoose.connection?.name || dbName;
     console.log(`Mongo connected: ${name}`);
+
+    // register models once after successful connection
+    if (!globalThis.__DG_MONGO_MODELS_REGISTERED__) {
+      try {
+        await import("../models/index.mjs");
+        globalThis.__DG_MONGO_MODELS_REGISTERED__ = true;
+      } catch (e) {
+        console.error("Failed to register models", e);
+      }
+    }
   }
   return mongoose;
 }

--- a/src/routes/debug.mjs
+++ b/src/routes/debug.mjs
@@ -20,7 +20,10 @@ router.get("/wire", async (_req, res) => {
   });
 });
 
-router.get("/mongoose", (_req, res) => {
+router.get("/mongoose", async (_req, res) => {
+  if (!mongoose.models?.CuratedCatalog || !mongoose.models?.BambooDump) {
+    try { await import("../models/index.mjs"); } catch {}
+  }
   const modelNames = typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [];
   res.json({
     ok: true,


### PR DESCRIPTION
## Summary
- extend stub mongoose module to track registered models and expose `modelNames`
- auto-register CuratedCatalog and BambooDump models after connecting
- ensure `/api/debug/mongoose` loads models before reporting them

## Testing
- `npm test` (fails: Missing script)
- `node -e "import('./src/db/mongoose.mjs').then(async ({mongoose})=>{await import('./src/models/index.mjs'); const {default:router}=await import('./src/routes/debug.mjs'); const req={}; const res={json:(x)=>console.log(JSON.stringify(x))}; const layer=router.stack.find(l=>l.route?.path=='/mongoose'); await layer.route.stack[0].handle(req,res);})"`

------
https://chatgpt.com/codex/tasks/task_e_68c06ea85570832bb7be8d8ada4785be