### PR TITLE
feat: implement Bamboo catalog export and curated categories

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,28 +1,29 @@
 // src/models/BambooDump.mjs
 import { mongoose } from "../db/mongoose.mjs";
 
-const BambooProductSchema = new mongoose.Schema(
+const BambooDumpItemSchema = new mongoose.Schema(
   {
+    brand: String,
     id: { type: Number, index: true },
     name: String,
-    brand: String,
     countryCode: String,
     currencyCode: String,
     priceMin: Number,
     priceMax: Number,
     modifiedDate: Date,
-    raw: {}
+    raw: {},
   },
   { _id: false }
 );
 
 const BambooDumpSchema = new mongoose.Schema(
   {
-    page: { type: Number, index: true },
-    pageSize: Number,
-    count: Number,
-    fetchedAt: { type: Date, default: Date.now, index: true },
-    products: [BambooProductSchema]
+    key: { type: String, index: true, unique: true },
+    items: [BambooDumpItemSchema],
+    pagesFetched: Number,
+    total: Number,
+    updatedAt: { type: Date, default: Date.now, index: true },
+    query: {},
   },
   { collection: "bamboo_dump" }
 );

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -10,16 +10,18 @@ const CuratedItemSchema = new mongoose.Schema(
     currencyCode: String,
     price: Number,
     logos: [String],
-    raw: {} // повний сирий bamboo item
+    raw: {},
   },
   { _id: false }
 );
 
 const CuratedSchema = new mongoose.Schema(
   {
-    key: { type: String, required: true, unique: true }, // наприклад "gaming"
+    key: { type: String, required: true, unique: true },
     updatedAt: { type: Date, default: Date.now, index: true },
-    items: [CuratedItemSchema]
+    items: [CuratedItemSchema],
+    currencies: [String],
+    source: {},
   },
   { collection: "curated_catalog" }
 );

--- a/src/routes/curated.mjs
+++ b/src/routes/curated.mjs
@@ -1,163 +1,34 @@
-import express from "express";
-import { BambooDump } from "../models/BambooDump.mjs";
+// src/routes/curated.mjs
+import { Router } from "express";
+import { buildCurated, getCuratedSection } from "../services/curate.mjs";
 import { CuratedCatalog } from "../models/CuratedCatalog.mjs";
 
-export const curatedRouter = express.Router();
+export const curatedRouter = Router();
 
-/** Ключові слова → категорії/лейбли брендів */
-const BRAND_MAP = [
-  // Gaming
-  { key: "gaming", label: "PlayStation", match: /playstation|psn|ps[\s-]?store/i },
-  { key: "gaming", label: "Xbox",       match: /xbox|microsoft xbox/i },
-  { key: "gaming", label: "Nintendo",   match: /nintendo/i },
-  { key: "gaming", label: "Steam",      match: /steam/i },
-  // Streaming
-  { key: "streaming", label: "Twitch",  match: /twitch/i },
-  // Shopping
-  { key: "shopping", label: "Amazon",   match: /\bamazon\b/i },
-  { key: "shopping", label: "eBay",     match: /\bebay\b/i },
-  { key: "shopping", label: "Zalando",  match: /zalando/i },
-  // Music
-  { key: "music", label: "Spotify",     match: /spotify/i },
-  { key: "music", label: "Google Play", match: /google\s*play|google\s*gift/i },
-  { key: "music", label: "Apple",       match: /\bapple\b|itunes/i },
-  // Food & Drink
-  { key: "food", label: "Starbucks",    match: /starbucks/i },
-  { key: "food", label: "Uber Eats",    match: /uber\s*eats/i },
-  // Travel
-  { key: "travel", label: "Airbnb",     match: /airbnb/i },
-  { key: "travel", label: "Uber",       match: /^uber$/i },
-];
-
-const CATEGORY_KEYS = ["gaming", "streaming", "shopping", "music", "food", "travel"];
-
-/** Нормалізація продукту під фронт */
-function normalizeProduct(brand, p) {
-  // Формати у v2 можуть відрізнятись — страхуємося опціональностями
-  const priceMin = p?.price?.min ?? p?.priceMin ?? p?.minFaceValue ?? null;
-  const priceMax = p?.price?.max ?? p?.priceMax ?? p?.maxFaceValue ?? null;
-  const currency = p?.price?.currencyCode ?? p?.currencyCode ?? brand?.currencyCode ?? null;
-
-  return {
-    id: p?.id ?? p?.productId ?? null,
-    name: p?.name || brand?.name || "",
-    brandId: brand?.brandId ?? brand?.id ?? null,
-    brandName: brand?.name || "",
-    countryCode: brand?.countryCode || null,
-    currencyCode: currency,
-    price: {
-      min: Number.isFinite(+priceMin) ? +priceMin : null,
-      max: Number.isFinite(+priceMax) ? +priceMax : null,
-    },
-    modifiedDate: p?.modifiedDate || brand?.modifiedDate || null,
-    logoUrl: brand?.logoUrl || null,
-  };
-}
-
-/** Побудова всіх категорій з дампу */
-function buildCurated(rows, wantedCurrencies = []) {
-  const res = {
-    gaming:    { items: [], count: 0, currencies: [] },
-    streaming: { items: [], count: 0, currencies: [] },
-    shopping:  { items: [], count: 0, currencies: [] },
-    music:     { items: [], count: 0, currencies: [] },
-    food:      { items: [], count: 0, currencies: [] },
-    travel:    { items: [], count: 0, currencies: [] },
-  };
-
-  for (const brand of rows || []) {
-    const name = brand?.name || "";
-    const hit = BRAND_MAP.find((b) => b.match.test(name));
-    if (!hit) continue;
-
-    const products = Array.isArray(brand?.products) ? brand.products : [];
-    for (const p of products) {
-      const np = normalizeProduct(brand, p);
-      if (!np.id) continue;
-
-      // Валютний фільтр (необов'язковий)
-      if (Array.isArray(wantedCurrencies) && wantedCurrencies.length > 0) {
-        if (np.currencyCode && !wantedCurrencies.includes(np.currencyCode)) continue;
-      }
-
-      res[hit.key].items.push(np);
-    }
-  }
-
-  // Підрахунок та множини валют
-  for (const k of CATEGORY_KEYS) {
-    const curSet = new Set();
-    for (const it of res[k].items) if (it.currencyCode) curSet.add(it.currencyCode);
-    res[k].currencies = Array.from(curSet);
-    res[k].count = res[k].items.length;
-  }
-
-  return res;
-}
-
-/** GET /api/curated/refresh?currencies=USD,EUR,CAD,AUD&dumpKey=... */
-curatedRouter.get("/refresh", async (req, res) => {
-  try {
-    const currencies = String(req.query.currencies || "")
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-
-    const dumpKey =
-      String(req.query.dumpKey || "") ||
-      `catalog:v2:ps${Number(process.env.CATALOG_PAGE_SIZE || 100)}:mp${Number(process.env.CATALOG_MAX_PAGES || 30)}`;
-
-    const dump = await BambooDump.findOne({ key: dumpKey }).lean();
-    if (!dump) {
-      return res.status(404).json({
-        ok: false,
-        error: `Dump not found for key=${dumpKey}. Спочатку виконай /api/bamboo/export.json?force=1`,
-      });
-    }
-
-    const curated = buildCurated(dump.rows, currencies);
-
-    // Зберігаємо кожну категорію окремо
-    const ops = [];
-    for (const k of CATEGORY_KEYS) {
-      ops.push(
-        CuratedCatalog.updateOne(
-          { key: k },
-          { $set: { key: k, data: curated[k], updatedAt: new Date() } },
-          { upsert: true }
-        )
-      );
-    }
-    await Promise.all(ops);
-
-    res.json({ ok: true, currencies, keys: CATEGORY_KEYS, dumpKey, counts: Object.fromEntries(CATEGORY_KEYS.map(k => [k, curated[k].count])) });
-  } catch (e) {
-    res.status(500).json({ ok: false, error: e?.message || String(e) });
-  }
+/** GET /api/curated/refresh?currencies=USD,EUR,CAD,AUD */
+curatedRouter.get("/curated/refresh", async (req, res) => {
+  const currencies = (req.query.currencies || "USD,EUR,CAD,AUD").split(",").map(s => s.trim()).filter(Boolean);
+  const out = await buildCurated({ currencies });
+  if (!out.ok) return res.status(400).json(out);
+  return res.json(out);
 });
 
-/** GET /api/curated/:key  (key ∈ gaming|streaming|shopping|music|food|travel) */
-curatedRouter.get("/:key", async (req, res) => {
-  try {
-    const key = String(req.params.key || "").toLowerCase();
-    if (!CATEGORY_KEYS.includes(key)) {
-      return res.status(400).json({ ok: false, error: `Unknown category key: ${key}` });
-    }
-    const doc = await CuratedCatalog.findOne({ key }).lean();
-    if (!doc) return res.json({ ok: true, key, data: { items: [], currencies: [], count: 0 } });
-    res.json({ ok: true, key, data: doc.data, updatedAt: doc.updatedAt });
-  } catch (e) {
-    res.status(500).json({ ok: false, error: e?.message || String(e) });
-  }
+/** GET /api/curated/status */
+curatedRouter.get("/curated/status", async (_req, res) => {
+  const doc = await CuratedCatalog.findOne({ key: "default" }).lean();
+  res.json({
+    ok: true,
+    updatedAt: doc?.updatedAt || null,
+    currencies: doc?.currencies || [],
+    source: doc?.source || {},
+  });
 });
 
-/** Статус кешу */
-curatedRouter.get("/status", async (_req, res) => {
-  try {
-    const docs = await CuratedCatalog.find({}).select({ key: 1, updatedAt: 1, "data.count": 1 }).lean();
-    res.json({ ok: true, items: docs || [] });
-  } catch (e) {
-    res.status(500).json({ ok: false, error: e?.message || String(e) });
-  }
+/** GET /api/curated/gaming */
+curatedRouter.get("/curated/gaming", async (_req, res) => {
+  const out = await getCuratedSection("gaming");
+  res.json(out);
 });
+
+export default curatedRouter;
 

--- a/src/services/bambooClient.mjs
+++ b/src/services/bambooClient.mjs
@@ -1,0 +1,56 @@
+import axios from "axios";
+
+const BASE = process.env.BAMBOO_BASE_URL || "https://api.bamboocardportal.com";
+const CATALOG_PATH = process.env.BAMBOO_CATALOG_PATH || "/api/integration/v2.0/catalog";
+const TIMEOUT = +(process.env.FETCH_TIMEOUT_MS || 15000);
+
+function basicAuthHeader() {
+  const id = process.env.BAMBOO_CLIENT_ID;
+  const secret = process.env.BAMBOO_CLIENT_SECRET;
+  if (!id || !secret) throw new Error("Bamboo Basic credentials missing");
+  const token = Buffer.from(`${id}:${secret}`).toString("base64");
+  return { Authorization: `Basic ${token}` };
+}
+
+/**
+ * Fetch one page from Bamboo catalog v2 with optional filters.
+ * Supports params like: CurrencyCode, CountryCode, Name, ModifiedDate, ProductId, PageSize, PageIndex, BrandId, TargetCurrency
+ */
+export async function fetchCatalogPage(params = {}) {
+  const url = `${BASE}${CATALOG_PATH}`;
+  const headers = {
+    "Content-Type": "application/json",
+    ...basicAuthHeader(),
+  };
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && `${v}` !== "") qs.append(k, v);
+  }
+  const finalUrl = `${url}?${qs.toString()}`;
+
+  const res = await axios.get(finalUrl, { headers, timeout: TIMEOUT, validateStatus: () => true });
+  if (res.status === 429) {
+    const msg = res.data?.reason || "Too many requests";
+    throw Object.assign(new Error(`Bamboo 429: ${msg}`), { status: 429 });
+  }
+  if (res.status !== 200) {
+    const msg = res.data?.reason || `Unexpected status ${res.status}`;
+    throw Object.assign(new Error(msg), { status: res.status });
+  }
+  return res.data; // expected shape: { pageindex, pageSize, count, items: [ { name, products: [...] } ] }
+}
+
+/** Paged fetch with guard and early-stop by empty pages */
+export async function fetchCatalogPaged({ PageSize = 100, maxPages = 30, PageIndex = 0, ...filters } = {}, onPage) {
+  let pageIndex = +PageIndex || 0;
+  const limit = Math.max(1, +maxPages || 1);
+  const pageSize = Math.max(1, +PageSize || 100);
+
+  for (let i = 0; i < limit; i++) {
+    const data = await fetchCatalogPage({ ...filters, PageSize: pageSize, PageIndex: pageIndex });
+    if (!data || !Array.isArray(data.items) || data.items.length === 0) break;
+    await onPage?.(data, pageIndex);
+    pageIndex++;
+  }
+}
+

--- a/src/services/curate.mjs
+++ b/src/services/curate.mjs
@@ -1,0 +1,151 @@
+import { CuratedCatalog } from "../models/CuratedCatalog.mjs";
+import { BambooDump } from "../models/BambooDump.mjs";
+
+const BRAND_TO_CATEGORY = {
+  // Gaming
+  "PlayStation": "gaming",
+  "PSN": "gaming",
+  "Sony PlayStation": "gaming",
+  "Xbox": "gaming",
+  "Microsoft Xbox": "gaming",
+  "Nintendo": "gaming",
+  "Steam": "gaming",
+
+  // Streaming
+  "Twitch": "streaming",
+  "Netflix": "streaming",
+  "Disney+": "streaming",
+
+  // Shopping
+  "Amazon": "shopping",
+  "eBay": "shopping",
+  "Zalando": "shopping",
+
+  // Music
+  "Spotify": "music",
+  "Apple Music": "music",
+  "Google Play": "music",
+
+  // Food & drink
+  "Starbucks": "food",
+  "Uber Eats": "food",
+
+  // Travel
+  "Airbnb": "travel",
+  "Uber": "travel",
+};
+
+function norm(s) {
+  return (s || "").toString().trim().toLowerCase();
+}
+
+// простий нормалізатор назви брендів (щоб ловити варіанти)
+function normalizeBrand(name) {
+  const n = norm(name);
+  if (/playstation|psn/.test(n)) return "PlayStation";
+  if (/xbox/.test(n)) return "Xbox";
+  if (/nintendo/.test(n)) return "Nintendo";
+  if (/steam/.test(n)) return "Steam";
+  if (/twitch/.test(n)) return "Twitch";
+  if (/zalando/.test(n)) return "Zalando";
+  if (/amazon/.test(n)) return "Amazon";
+  if (/\be(-)?bay\b/.test(n)) return "eBay";
+  if (/spotify/.test(n)) return "Spotify";
+  if (/apple\s?music/.test(n)) return "Apple Music";
+  if (/google\s?play/.test(n)) return "Google Play";
+  if (/starbucks/.test(n)) return "Starbucks";
+  if (/uber\s?eats/.test(n)) return "Uber Eats";
+  if (/airbnb/.test(n)) return "Airbnb";
+  if (/^\s*uber\s*$/.test(n)) return "Uber";
+  return name || "Unknown";
+}
+
+export async function buildCurated({ currencies = ["USD", "EUR", "CAD", "AUD"] } = {}) {
+  // беремо будь-який останній дамп
+  const dump = await BambooDump.findOne({}, {}, { sort: { updatedAt: -1 } }).lean();
+  if (!dump?.items?.length) {
+    return { ok: false, reason: "No BambooDump data yet" };
+  }
+
+  const byCategory = {
+    gaming: [],
+    streaming: [],
+    shopping: [],
+    music: [],
+    food: [],
+    travel: [],
+  };
+
+  for (const it of dump.items) {
+    const brand = normalizeBrand(it.brand);
+    const category = BRAND_TO_CATEGORY[brand];
+    if (!category) continue;
+
+    // мапимо в кілька валют (якщо в сирих даних валют кілька — можна розширити)
+    const curr = it.currencyCode || it.raw?.price?.currencyCode || null;
+    const possibleCurrencies = curr ? [curr] : currencies;
+
+    for (const cc of possibleCurrencies) {
+      byCategory[category].push({
+        productId: it.id,
+        name: it.name,
+        brand,
+        countryCode: it.countryCode || it.raw?.countryCode || null,
+        currencyCode: cc,
+        price: it.priceMin ?? it.priceMax ?? it.raw?.price?.min ?? it.raw?.price?.max ?? null,
+        logos: it.raw?.logoUrl ? [it.raw.logoUrl] : [],
+        raw: { id: it.id, brand: it.brand, currencyCode: curr, ...it.raw },
+      });
+    }
+  }
+
+  const key = "default";
+  const payload = {
+    key,
+    items: [
+      // Можна зберігати плоский масив або додати groups — зараз збережемо групи в source
+    ],
+    currencies,
+    source: {
+      bambooPages: dump.pagesFetched || 0,
+      bambooCount: dump.total || dump.items.length,
+      groups: Object.fromEntries(Object.entries(byCategory).map(([k, v]) => [k, v.length])),
+    },
+    updatedAt: new Date(),
+  };
+
+  await CuratedCatalog.findOneAndUpdate(
+    { key },
+    { $set: payload },
+    { upsert: true, new: true }
+  );
+
+  return { ok: true, counts: payload.source.groups };
+}
+
+export async function getCuratedSection(section = "gaming") {
+  const doc = await CuratedCatalog.findOne({ key: "default" }).lean();
+  if (!doc) return { ok: false, items: [] };
+  // просто на основі останнього дампа повторно побудуємо секцію (щоб не тримати дубль)
+  const dump = await BambooDump.findOne({}, {}, { sort: { updatedAt: -1 } }).lean();
+  if (!dump?.items?.length) return { ok: false, items: [] };
+
+  const result = [];
+  for (const it of dump.items) {
+    const brand = normalizeBrand(it.brand);
+    const category = BRAND_TO_CATEGORY[brand];
+    if (category !== section) continue;
+    const cc = it.currencyCode || it.raw?.price?.currencyCode || null;
+    result.push({
+      productId: it.id,
+      name: it.name,
+      brand,
+      countryCode: it.countryCode || it.raw?.countryCode || null,
+      currencyCode: cc,
+      price: it.priceMin ?? it.priceMax ?? it.raw?.price?.min ?? it.raw?.price?.max ?? null,
+      logos: it.raw?.logoUrl ? [it.raw.logoUrl] : [],
+    });
+  }
+  return { ok: true, items: result };
+}
+


### PR DESCRIPTION
## Summary
- add Bamboo API client and export route to cache catalog in Mongo
- build curated catalog groups and expose refresh/status/gaming endpoints
- wire new routers in server with optional auto-refresh

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c16a95e3ac832b8ed30b3292b4b431