### PR TITLE
fix: implement findOne in mongoose stub

### DIFF
--- a/node_modules/mongoose/index.js
+++ b/node_modules/mongoose/index.js
@@ -29,6 +29,14 @@ export function model(name, schema) {
       const collection = client.db().collection(collectionName);
       return collection.insertOne(doc);
     },
+    findOne: (filter = {}, projection = {}, options = {}) => {
+      if (!client) throw new Error('MongoClient not connected');
+      const collection = client.db().collection(collectionName);
+      let cursor = collection.find(filter, { projection });
+      if (options.sort) cursor = cursor.sort(options.sort);
+      const promise = cursor.limit(1).next();
+      return { lean: () => promise };
+    },
     findOneAndUpdate: (filter, update) => {
       if (!client) throw new Error('MongoClient not connected');
       const collection = client.db().collection(collectionName);


### PR DESCRIPTION
## Summary
- add findOne with lean support to mongoose stub
- enable curated service queries to work as intended

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --input-type=module -e "import {BambooDump} from './src/models/BambooDump.mjs'; console.log('findOne exists?', typeof BambooDump.findOne);"`

------
https://chatgpt.com/codex/tasks/task_e_68c171525598832b949098ccc5d170dd