### PR TITLE
Add find support to mongoose stub

### DIFF
--- a/node_modules/mongoose/index.js
+++ b/node_modules/mongoose/index.js
@@ -29,6 +29,21 @@ export function model(name, schema) {
       const collection = client.db().collection(collectionName);
       return collection.insertOne(doc);
     },
+    find: (filter = {}, projection = {}) => {
+      if (!client) throw new Error('MongoClient not connected');
+      const collection = client.db().collection(collectionName);
+      let cursor = collection.find(filter, { projection });
+      const chain = {
+        sort(sort) {
+          cursor = cursor.sort(sort);
+          return chain;
+        },
+        lean() {
+          return cursor.toArray();
+        }
+      };
+      return chain;
+    },
     findOne: (filter = {}, projection = {}, options = {}) => {
       if (!client) throw new Error('MongoClient not connected');
       const collection = client.db().collection(collectionName);
@@ -41,6 +56,11 @@ export function model(name, schema) {
       if (!client) throw new Error('MongoClient not connected');
       const collection = client.db().collection(collectionName);
       return collection.findOneAndUpdate(filter, { $set: update });
+    },
+    deleteOne: (filter = {}) => {
+      if (!client) throw new Error('MongoClient not connected');
+      const collection = client.db().collection(collectionName);
+      return collection.deleteOne(filter);
     }
   };
   models[name] = m;


### PR DESCRIPTION
## Summary
- add `find` and `deleteOne` methods to mongoose stub so BambooDump can query multiple records

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c40e46e528832ba9c98764980541ee