### PR TITLE
Fix Bamboo export persistence and add inspector

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -39,10 +39,12 @@ async function bootstrap() {
   // Імпортуємо роутери
   const { default: debugRouter } = await import("./src/routes/debug.mjs");
   const { bambooExportRouter } = await import("./src/routes/bamboo-export.mjs");
+  const { bambooItemsRouter } = await import("./src/routes/bamboo-items.mjs");
   const { bambooStatusRouter } = await import("./src/routes/bamboo-status.mjs");
   const { curatedRouter } = await import("./src/routes/curated.mjs");
   app.use("/api", debugRouter);
   app.use("/api", bambooExportRouter);
+  app.use("/api", bambooItemsRouter);
   app.use("/api", bambooStatusRouter);
   app.use("/api", curatedRouter);
 

--- a/src/routes/bamboo-items.mjs
+++ b/src/routes/bamboo-items.mjs
@@ -1,0 +1,26 @@
+// src/routes/bamboo-items.mjs
+import { Router } from "express";
+import { BambooDump } from "../models/BambooDump.mjs";
+
+export const bambooItemsRouter = Router();
+
+/** Швидкий перегляд останнього дампа */
+bambooItemsRouter.get("/bamboo/items", async (req, res) => {
+  const limit = Math.max(1, Math.min(100, parseInt(req.query.limit || "20", 10)));
+  const dump = await BambooDump.findOne({}, {}, { sort: { updatedAt: -1 } }).lean();
+  const count = dump?.items?.length || 0;
+  const sample = dump?.items?.slice(0, limit) || [];
+  res.json({
+    ok: true,
+    count,
+    sampleMeta: sample.map(x => ({
+      id: x.id,
+      brand: x.brand,
+      name: x.name,
+      countryCode: x.countryCode,
+      currencyCode: x.currencyCode,
+      priceMin: x.priceMin,
+      priceMax: x.priceMax,
+    })),
+  });
+});

--- a/src/routes/bamboo-status.mjs
+++ b/src/routes/bamboo-status.mjs
@@ -6,7 +6,18 @@ import { BambooDump } from "../models/BambooDump.mjs";
 export const bambooStatusRouter = Router();
 
 bambooStatusRouter.get("/bamboo/status", async (req, res) => {
-  const dumps = await BambooDump.find({}, { key:1, pagesFetched:1, total:1, lastPage:1, pageSize:1, updatedAt:1 }).sort({ updatedAt:-1 }).lean();
+  let dumps = await BambooDump.find({}, { key:1, pagesFetched:1, total:1, lastPage:1, pageSize:1, updatedAt:1, items:1 })
+    .sort({ updatedAt:-1 })
+    .lean();
+  dumps = dumps.map(d => ({
+    key: d.key,
+    pagesFetched: d.pagesFetched,
+    total: d.total,
+    lastPage: d.lastPage,
+    pageSize: d.pageSize,
+    updatedAt: d.updatedAt,
+    count: Array.isArray(d.items) ? d.items.length : 0,
+  }));
   const rl = await RateLimit.findOne({ key: "bamboo:catalog" }).lean();
   res.json({ ok:true, rateLimit: rl?.nextRetryAt || null, dumps });
 });


### PR DESCRIPTION
## Summary
- persist Bamboo export progress with additional telemetry and saved item reporting
- add /api/bamboo/items inspector endpoint and expose saved counts in status
- improve curated build failure messaging and include Bamboo dump stats in responses

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c85238bdb8832b93e240068a43282d