### PR TITLE
Fix mongoose stub schema index support

### DIFF
--- a/node_modules/mongoose/index.js
+++ b/node_modules/mongoose/index.js
@@ -15,14 +15,28 @@ export async function connect(uri, options = {}) {
 }
 
 export class Schema {
-  constructor(definition) {
+  constructor(definition = {}, options = {}) {
     this.definition = definition;
+    this.options = options;
+    this._indexes = [];
+  }
+
+  index(fields, options = {}) {
+    if (!fields || typeof fields !== 'object') {
+      throw new TypeError('Schema.index requires a fields object');
+    }
+    this._indexes.push({ fields, options });
+    return this;
+  }
+
+  getIndexes() {
+    return this._indexes.map(({ fields, options }) => ({ fields: { ...fields }, options: { ...options } }));
   }
 }
 
 export function model(name, schema) {
   if (models[name]) return models[name];
-  const collectionName = name.toLowerCase();
+  const collectionName = schema?.options?.collection || name.toLowerCase();
   const m = {
     create: (doc) => {
       if (!client) throw new Error('MongoClient not connected');


### PR DESCRIPTION
## Summary
- extend the mongoose stub Schema class to keep options and track declared indexes
- expose a Schema.index method so bamboo page schema registration no longer crashes
- make the stubbed model creator respect the collection name from schema options

## Testing
- node -e "import('./src/models/BambooPage.mjs').catch(e=>{console.error(e); process.exit(1);})"


------
https://chatgpt.com/codex/tasks/task_e_68c959a9b364832bbdaf19efcd44f07a