### PR TITLE
Fix mongoose singleton + native collection helper

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -30,17 +30,16 @@ const BambooDumpSchema = new mongoose.Schema(
   { collection: "bamboo_dump" }
 );
 
-// ensure we always expose a real model with deleteOne
-let BambooDumpModel = mongoose.models?.BambooDump;
-if (BambooDumpModel && typeof BambooDumpModel.deleteOne !== "function") {
-  // remove broken registration and recompile
+let existing = mongoose.models?.BambooDump;
+if (existing && typeof existing.deleteOne !== "function") {
   delete mongoose.models.BambooDump;
-  BambooDumpModel = undefined;
+  existing = undefined;
 }
-if (!BambooDumpModel) {
-  BambooDumpModel = mongoose.model("BambooDump", BambooDumpSchema);
-}
-export const BambooDump = BambooDumpModel;
+
+const _Model = existing || mongoose.model("BambooDump", BambooDumpSchema);
+
+export const BambooDump = _Model;
+export default _Model;
 
 // sanity log (once) + safe fallback
 if (typeof BambooDump?.deleteOne !== "function") {

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -26,8 +26,11 @@ const CuratedSchema = new mongoose.Schema(
   { collection: "curated_catalog" }
 );
 
-export const CuratedCatalog =
+const _Model =
   (mongoose.models?.CuratedCatalog) || mongoose.model("CuratedCatalog", CuratedSchema);
+
+export const CuratedCatalog = _Model;
+export default _Model;
 
 if (typeof CuratedCatalog?.findOne !== "function") {
   console.error("[CuratedCatalog] exported value is not a real Mongoose Model");


### PR DESCRIPTION
## Summary
- replace the mongoose helper with a simple singleton export that also exposes a native collection accessor
- align BambooDump and CuratedCatalog models so their named and default exports share the same instance
- harden the bamboo export route by using the helper for native collection access and improving saved item aggregation fallbacks

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9b0fac358832b842bb315e9461c02