### PR TITLE
Align BambooPage exports and add diagnostics

### DIFF
--- a/src/models/BambooPage.mjs
+++ b/src/models/BambooPage.mjs
@@ -1,8 +1,9 @@
+// src/models/BambooPage.mjs
 import { mongoose } from "../db/mongoose.mjs";
 
-const ItemSchema = new mongoose.Schema(
+const BambooProductSchema = new mongoose.Schema(
   {
-    id: Number,
+    id: { type: Number, index: true },
     name: String,
     brand: String,
     countryCode: String,
@@ -15,26 +16,30 @@ const ItemSchema = new mongoose.Schema(
   { _id: false }
 );
 
-const Schema = new mongoose.Schema(
+const BambooPageSchema = new mongoose.Schema(
   {
     key: { type: String, required: true, index: true },
     pageIndex: { type: Number, required: true, index: true },
-    items: { type: [ItemSchema], default: [] },
+    items: { type: [BambooProductSchema], default: [] },
     updatedAt: { type: Date, default: Date.now, index: true },
   },
   { collection: "bamboo_pages" }
 );
 
-Schema.index({ key: 1, pageIndex: 1 }, { unique: true });
+BambooPageSchema.index({ key: 1, pageIndex: 1 }, { unique: true });
 
-const _Model =
-  (mongoose.models?.BambooPage) || mongoose.model("BambooPage", Schema);
+// IMPORTANT: compile once on the singleton mongoose instance
+const Model =
+  (mongoose.models && mongoose.models.BambooPage) ||
+  mongoose.model("BambooPage", BambooPageSchema);
 
-export const BambooPage = _Model;
-export default _Model;
+// Named + default exports MUST point to the SAME object
+export const BambooPage = Model;
+export default Model;
 
+// Log AFTER model is created so modelName is not null
 console.log("[model] BambooPage ready:", {
   modelName: BambooPage?.modelName || null,
   hasFind: typeof BambooPage?.find === "function",
-  hasFindOneAndUpdate: typeof BambooPage?.findOneAndUpdate === "function",
+  hasF1U: typeof BambooPage?.findOneAndUpdate === "function",
 });

--- a/src/routes/bamboo-pages.mjs
+++ b/src/routes/bamboo-pages.mjs
@@ -4,10 +4,19 @@ import { BambooPage } from "../models/BambooPage.mjs";
 
 export const bambooPagesRouter = Router();
 
-/** GET /api/bamboo/pages */
 bambooPagesRouter.get("/bamboo/pages", async (_req, res) => {
   const dump = await BambooDump.findOne({}, {}, { sort: { updatedAt: -1 } }).lean();
-  if (!dump) return res.json({ ok: true, pages: [] });
-  const pages = await BambooPage.find({ key: dump.key }, { items: 0 }).sort({ pageIndex: 1 }).lean();
-  res.json({ ok: true, key: dump.key, pages });
+  if (!dump) return res.json({ ok: true, key: null, pages: [], savedItems: 0 });
+
+  const key = dump.key;
+  const pages = await BambooPage.find({ key }, { items: 0 }).sort({ pageIndex: 1 }).lean();
+  let savedItems = 0;
+  const withCounts = [];
+  for (const p of pages) {
+    const page = await BambooPage.findOne({ key, pageIndex: p.pageIndex }, { items: 1 }).lean();
+    const cnt = Array.isArray(page?.items) ? page.items.length : 0;
+    savedItems += cnt;
+    withCounts.push({ pageIndex: p.pageIndex, count: cnt, updatedAt: p.updatedAt });
+  }
+  res.json({ ok: true, key, pages: withCounts, savedItems });
 });


### PR DESCRIPTION
## Summary
- ensure the BambooPage mongoose model has matching named and default exports on the compiled model
- expand the bamboo pages diagnostic route to report saved item counts
- adjust bamboo export response to include the saved page list and recomputed saved item totals

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9605c4c4832bb21753d17f1371a6