### PR TITLE
Ensure BambooPage uses singleton mongoose model

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -43,12 +43,14 @@ async function bootstrap() {
   await import("./src/models/CuratedCatalog.mjs");
 
   // Імпортуємо роутери
+  const { debugModelRouter } = await import("./src/routes/debug-model.mjs");
   const { default: debugRouter } = await import("./src/routes/debug.mjs");
   const { bambooExportRouter } = await import("./src/routes/bamboo-export.mjs");
   const { bambooItemsRouter } = await import("./src/routes/bamboo-items.mjs");
   const { bambooPagesRouter } = await import("./src/routes/bamboo-pages.mjs");
   const { bambooStatusRouter } = await import("./src/routes/bamboo-status.mjs");
   const { curatedRouter } = await import("./src/routes/curated.mjs");
+  app.use("/api", debugModelRouter);
   app.use("/api", debugRouter);
   app.use("/api", bambooExportRouter);
   app.use("/api", bambooItemsRouter);
@@ -56,9 +58,8 @@ async function bootstrap() {
   app.use("/api", bambooStatusRouter);
   app.use("/api", curatedRouter);
 
-  // Log what's registered
-  const names = typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [];
-  console.log("🧩 Models registered:", names);
+  // Лог зареєстрованих моделей на singleton-інстансі
+  console.log("🧩 Models registered:", mongoose.modelNames());
 
   app.listen(PORT, () => {
     console.log(`Server on :${PORT}`);

--- a/src/models/BambooPage.mjs
+++ b/src/models/BambooPage.mjs
@@ -28,18 +28,17 @@ const BambooPageSchema = new mongoose.Schema(
 
 BambooPageSchema.index({ key: 1, pageIndex: 1 }, { unique: true });
 
-// IMPORTANT: compile once on the singleton mongoose instance
+// compile on the singleton mongoose instance
 const Model =
-  (mongoose.models && mongoose.models.BambooPage) ||
-  mongoose.model("BambooPage", BambooPageSchema);
+  (mongoose.models?.BambooPage) || mongoose.model("BambooPage", BambooPageSchema);
 
-// Named + default exports MUST point to the SAME object
+// named + default must point to the SAME object (the real model)
 export const BambooPage = Model;
 export default Model;
 
-// Log AFTER model is created so modelName is not null
+// sanity log AFTER model creation
 console.log("[model] BambooPage ready:", {
   modelName: BambooPage?.modelName || null,
   hasFind: typeof BambooPage?.find === "function",
-  hasF1U: typeof BambooPage?.findOneAndUpdate === "function",
+  hasFindOneAndUpdate: typeof BambooPage?.findOneAndUpdate === "function",
 });

--- a/src/routes/debug-model.mjs
+++ b/src/routes/debug-model.mjs
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { mongoose } from "../db/mongoose.mjs";
+import { BambooPage } from "../models/BambooPage.mjs";
+import { BambooDump } from "../models/BambooDump.mjs";
+import { CuratedCatalog } from "../models/CuratedCatalog.mjs";
+
+export const debugModelRouter = Router();
+
+debugModelRouter.get("/debug/model/BambooPage", (_req, res) => {
+  res.json({
+    ok: true,
+    modelName: BambooPage?.modelName || null,
+    hasFind: typeof BambooPage?.find === "function",
+    hasF1U: typeof BambooPage?.findOneAndUpdate === "function",
+    singletonModelNames:
+      typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [],
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild BambooPage to compile directly on the shared mongoose singleton and emit readiness diagnostics
- keep bootstrap on the singleton by force-loading models, registering the new debug endpoint and logging model names
- add an express debug route that confirms the real BambooPage model is wired on the singleton instance

## Testing
- not run (MongoDB instance not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68cabd867540832bb59d1d78fbd8d075