### PR TITLE
Update debug model diagnostics output

### DIFF
--- a/src/routes/debug-model.mjs
+++ b/src/routes/debug-model.mjs
@@ -1,8 +1,6 @@
 import { Router } from "express";
 import { mongoose } from "../db/mongoose.mjs";
 import { BambooPage } from "../models/BambooPage.mjs";
-import { BambooDump } from "../models/BambooDump.mjs";
-import { CuratedCatalog } from "../models/CuratedCatalog.mjs";
 
 export const debugModelRouter = Router();
 
@@ -12,7 +10,6 @@ debugModelRouter.get("/debug/model/BambooPage", (_req, res) => {
     modelName: BambooPage?.modelName || null,
     hasFind: typeof BambooPage?.find === "function",
     hasF1U: typeof BambooPage?.findOneAndUpdate === "function",
-    singletonModelNames:
-      typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [],
+    registered: typeof mongoose.modelNames === "function" ? mongoose.modelNames() : [],
   });
 });


### PR DESCRIPTION
## Summary
- align the debug BambooPage route with the new diagnostics schema by returning `registered`

## Testing
- not run (MongoDB connection string required)


------
https://chatgpt.com/codex/tasks/task_e_68caeae34e1c832ba7d0b7c181e7fad1