### PR TITLE
Align BambooPage model wiring

### DIFF
--- a/src/models/BambooPage.mjs
+++ b/src/models/BambooPage.mjs
@@ -31,7 +31,6 @@ BambooPageSchema.index({ key: 1, pageIndex: 1 }, { unique: true });
 const Model =
   (mongoose.models?.BambooPage) || mongoose.model("BambooPage", BambooPageSchema);
 
-// named + default = той самий об’єкт (РЕАЛЬНА модель!)
 export const BambooPage = Model;
 export default Model;
 

--- a/src/routes/debug-model.mjs
+++ b/src/routes/debug-model.mjs
@@ -11,5 +11,6 @@ debugModelRouter.get("/debug/model/BambooPage", (_req, res) => {
     hasFind: typeof BambooPage?.find === "function",
     hasF1U: typeof BambooPage?.findOneAndUpdate === "function",
     registered: mongoose.modelNames(),
+    moduleUrl: import.meta.url,
   });
 });


### PR DESCRIPTION
## Summary
- align the BambooPage model file with the canonical schema/export definition
- extend the debug model route payload to expose its module URL for diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc25e92610832bb3b911a92daf63a7