### PR TITLE
Fix mongoose stub to expose modelName for models

### DIFF
--- a/node_modules/mongoose/index.js
+++ b/node_modules/mongoose/index.js
@@ -35,7 +35,18 @@ export class Schema {
 }
 
 export function model(name, schema) {
-  if (models[name]) return models[name];
+  if (models[name]) {
+    const existing = models[name];
+    if (existing.modelName !== name) {
+      Object.defineProperty(existing, 'modelName', {
+        value: name,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+    return existing;
+  }
   const collectionName = schema?.options?.collection || name.toLowerCase();
   const m = {
     create: (doc) => {
@@ -77,6 +88,12 @@ export function model(name, schema) {
       return collection.deleteOne(filter);
     }
   };
+  Object.defineProperty(m, 'modelName', {
+    value: name,
+    writable: false,
+    enumerable: false,
+    configurable: false
+  });
   models[name] = m;
   return m;
 }


### PR DESCRIPTION
## Summary
- ensure the bundled mongoose stub attaches an immutable modelName property to newly created models
- patch cached models to also expose modelName so the bootstrap check passes

## Testing
- not run (requires MongoDB connection string)


------
https://chatgpt.com/codex/tasks/task_e_68cc30102b10832b93a37043d4dc33cb