### PR TITLE
Fix Bamboo export page persistence

### DIFF
--- a/src/routes/bamboo-pages.mjs
+++ b/src/routes/bamboo-pages.mjs
@@ -5,16 +5,23 @@ import { BambooPage } from "../models/BambooPage.mjs";
 export const bambooPagesRouter = Router();
 
 bambooPagesRouter.get("/bamboo/pages", async (_req, res) => {
-  const dump = await BambooDump.findOne({}, {}, { sort: { updatedAt: -1 } }).lean();
-  if (!dump) return res.json({ ok: true, key: null, pages: [], savedItems: 0 });
+  // беремо останній ключ, якщо є BambooDump; якщо ні — беремо будь-який наявний у BambooPage
+  let key = null;
+  const dump = await BambooDump.findOne({}, {}, { sort: { updatedAt: -1 } }).lean().catch(() => null);
+  if (dump?.key) key = dump.key;
+  if (!key) {
+    const any = await BambooPage.findOne({}, { key: 1 }, { sort: { updatedAt: -1 } }).lean().catch(() => null);
+    if (any?.key) key = any.key;
+  }
 
-  const key = dump.key;
+  if (!key) return res.json({ ok: true, key: null, pages: [], savedItems: 0 });
+
   const pages = await BambooPage.find({ key }, { items: 0 }).sort({ pageIndex: 1 }).lean();
   let savedItems = 0;
   const withCounts = [];
   for (const p of pages) {
-    const page = await BambooPage.findOne({ key, pageIndex: p.pageIndex }, { items: 1 }).lean();
-    const cnt = Array.isArray(page?.items) ? page.items.length : 0;
+    const doc = await BambooPage.findOne({ key, pageIndex: p.pageIndex }, { items: 1 }).lean();
+    const cnt = Array.isArray(doc?.items) ? doc.items.length : 0;
     savedItems += cnt;
     withCounts.push({ pageIndex: p.pageIndex, count: cnt, updatedAt: p.updatedAt });
   }


### PR DESCRIPTION
## Summary
- normalize bamboo export key construction from request query and upsert catalog pages with defaults while logging the saved document
- count persisted items from stored page documents when returning the export response
- add a diagnostic /api/bamboo/pages endpoint to inspect stored pages and item counts

## Testing
- node --check src/routes/bamboo-export.mjs
- node --check src/routes/bamboo-pages.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfab08ba60832b92436bf0b1402f08