### PR TITLE
fix: wait for native mongo collection and soften fallback

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -1,31 +1,71 @@
 // src/db/mongoose.mjs
 import mongoose from "mongoose";
 
-let connected = false;
+let connectPromise = null;
 
-export async function connectMongo() {
-  if (connected) return mongoose.connection;
-  const uri = process.env.MONGODB_URI;
+export async function connectMongo(uri, dbName) {
   if (!uri) throw new Error("MONGODB_URI not set");
-
-  // Безпечні опції для Mongoose >=7
-  await mongoose.connect(uri, {
-    // bufferCommands за замовчуванням true; залишаємо як є
-    // serverSelectionTimeoutMS: 10000,
-  });
-
-  connected = true;
-  console.log(`Mongo connected: ${mongoose.connection?.name || "(unknown)"}`);
+  if (!connectPromise) {
+    mongoose.set?.("strictQuery", true);
+    connectPromise = mongoose
+      .connect(uri, {
+        dbName: dbName || process.env.MONGODB_DB_NAME || undefined,
+        maxPoolSize: 10,
+        serverSelectionTimeoutMS: 15000,
+      })
+      .catch((e) => {
+        connectPromise = null;
+        throw e;
+      });
+  }
+  await connectPromise;
   return mongoose.connection;
 }
 
-// ЄДИНИЙ екземпляр — і named, і default
-export { mongoose };
-export default mongoose;
-
-// Безпечний доступ до нативної колекції
-export function getNativeCollection(name) {
-  const db = mongoose.connection?.db;
-  if (!db) throw new Error("Mongo connection DB is not ready");
-  return db.collection(name);
+export function isMongoReady() {
+  return mongoose?.connection?.readyState === 1;
 }
+
+/**
+ * Повертає native-колекцію. Якщо конекшен ще не відкритий — чекає.
+ * Таймаут очікування ~10с.
+ */
+export async function getNativeCollection(name) {
+  // якщо вже готово — повертаємо одразу
+  if (mongoose?.connection?.readyState === 1 && mongoose?.connection?.db) {
+    return mongoose.connection.db.collection(name);
+  }
+
+  // спроба дочекатися відкриття поточного конекшену
+  try {
+    // якщо є активний connectPromise — дочекаємося
+    if (connectPromise) {
+      await connectPromise;
+    } else if (mongoose?.connection?.asPromise) {
+      // для mongoose v7+
+      await mongoose.connection.asPromise();
+    } else {
+      // Фолбек: невеликий цикл очікування
+      const started = Date.now();
+      while (Date.now() - started < 10000) {
+        if (mongoose?.connection?.readyState === 1 && mongoose?.connection?.db) break;
+        await new Promise((r) => setTimeout(r, 200));
+      }
+    }
+  } catch (_) {
+    // ігноруємо — нижче ще раз перевіримо стан
+  }
+
+  if (mongoose?.connection?.readyState === 1 && mongoose?.connection?.db) {
+    return mongoose.connection.db.collection(name);
+  }
+
+  // повертаємо інформативну помилку (але тепер її не будемо кидати з роутів)
+  const state = mongoose?.connection?.readyState ?? null;
+  const nameInfo = mongoose?.connection?.name ?? null;
+  const msg = `Mongo connection DB is not ready (state=${state}, name=${nameInfo})`;
+  const err = new Error(msg);
+  err.code = "MONGO_NOT_READY";
+  throw err;
+}
+


### PR DESCRIPTION
## Summary
- ensure the mongoose connection helper caches the connect promise and waits for the native collection to become ready before returning
- update bamboo export fallbacks to await native collection access, logging and returning null instead of throwing when Mongo is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d58696c484832b9b07f238511007e5