### PR TITLE
Restore mongoose named export

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -1,5 +1,6 @@
 // src/db/mongoose.mjs
 import mongoose from "mongoose";
+export { default as mongoose } from "mongoose";
 
 let connectPromise = null;
 


### PR DESCRIPTION
## Summary
- restore the named export for mongoose in the database helper module so existing imports continue working

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f46f5a08832b992f2888c3a1b2dc