### PR TITLE
Add Mongo URI fallbacks and debug env route

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -5,12 +5,15 @@ export { default as mongoose } from "mongoose";
 let connectPromise = null;
 
 export async function connectMongo(uri, dbName) {
-  if (!uri) throw new Error("MONGODB_URI not set");
+  const finalUri = uri || process.env.MONGODB_URI || process.env.DB_URL || process.env.MONGO_URL;
+  if (!finalUri) {
+    throw new Error("MONGODB_URI/DB_URL not set");
+  }
   if (!connectPromise) {
     mongoose.set?.("strictQuery", true);
     connectPromise = mongoose
-      .connect(uri, {
-        dbName: dbName || process.env.MONGODB_DB_NAME || undefined,
+      .connect(finalUri, {
+        dbName: dbName || process.env.MONGODB_DB_NAME || process.env.DB_NAME || undefined,
         maxPoolSize: 10,
         serverSelectionTimeoutMS: 15000,
       })

--- a/src/routes/debug-env.mjs
+++ b/src/routes/debug-env.mjs
@@ -1,0 +1,30 @@
+import { Router } from "express";
+export const debugEnvRouter = Router();
+
+function mask(v) {
+  if (!v) return null;
+  if (v.length <= 6) return "***";
+  return v.slice(0, 3) + "***" + v.slice(-3);
+}
+
+debugEnvRouter.get("/debug/env", (_req, res) => {
+  res.json({
+    ok: true,
+    has: {
+      MONGODB_URI: !!process.env.MONGODB_URI,
+      DB_URL: !!process.env.DB_URL,
+      MONGO_URL: !!process.env.MONGO_URL,
+      MONGODB_DB_NAME: !!process.env.MONGODB_DB_NAME,
+      DB_NAME: !!process.env.DB_NAME,
+    },
+    sample: {
+      MONGODB_URI: mask(process.env.MONGODB_URI || ""),
+      DB_URL: mask(process.env.DB_URL || ""),
+    },
+    chosen: (process.env.MONGODB_URI && "MONGODB_URI") ||
+            (process.env.DB_URL && "DB_URL") ||
+            (process.env.MONGO_URL && "MONGO_URL") ||
+            null,
+    dbName: process.env.MONGODB_DB_NAME || process.env.DB_NAME || null,
+  });
+});


### PR DESCRIPTION
## Summary
- add Mongo connection bootstrap that falls back to DB_URL and MONGO_URL
- update connectMongo helper to accept provided URIs and database names
- introduce /api/debug/env route to inspect Mongo-related environment variables

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8097354fc832b9a1181c6fdc688a4