### PR TITLE
Remove native Mongo fallbacks from bamboo export route

### DIFF
--- a/src/models/BambooPage.mjs
+++ b/src/models/BambooPage.mjs
@@ -1,41 +1,20 @@
 // src/models/BambooPage.mjs
-import { mongoose } from "../db/mongoose.mjs";
-
-const BambooProductSchema = new mongoose.Schema(
-  {
-    id: { type: Number, index: true },
-    name: String,
-    brand: String,
-    countryCode: String,
-    currencyCode: String,
-    priceMin: Number,
-    priceMax: Number,
-    modifiedDate: Date,
-    raw: {},
-  },
-  { _id: false }
-);
+import mongoose from "mongoose";
 
 const BambooPageSchema = new mongoose.Schema(
   {
     key: { type: String, required: true, index: true },
     pageIndex: { type: Number, required: true, index: true },
-    items: { type: [BambooProductSchema], default: [] },
+    items: { type: Array, default: [] },
     updatedAt: { type: Date, default: Date.now, index: true },
   },
-  { collection: "bamboo_pages" }
+  { collection: "bamboo_pages", strict: false, minimize: false }
 );
 
+// унікальність пари key+pageIndex для апсерта
 BambooPageSchema.index({ key: 1, pageIndex: 1 }, { unique: true });
 
-const Model =
-  (mongoose.models?.BambooPage) || mongoose.model("BambooPage", BambooPageSchema);
+export const BambooPage =
+  mongoose.models.BambooPage || mongoose.model("BambooPage", BambooPageSchema);
 
-export const BambooPage = Model;
-export default Model;
-
-console.log("[model] BambooPage ready:", {
-  modelName: BambooPage?.modelName || null,
-  hasFind: typeof BambooPage?.find === "function",
-  hasFindOneAndUpdate: typeof BambooPage?.findOneAndUpdate === "function",
-});
+export default BambooPage;


### PR DESCRIPTION
## Summary
- align the BambooPage schema with the desired collection options and key index
- update bamboo export helpers to use only Mongoose for upserts, totals, and page listings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95a6eb93c832bba87da0008d4388e