### PR TITLE
Ensure reliable Bamboo page persistence and debugging

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -67,11 +67,19 @@ async function bootstrap() {
   await import("./src/models/BambooPage.mjs");
   await import("./src/models/CuratedCatalog.mjs");
 
-  const modelNames = mongoose.modelNames();
-  console.log("🧩 Models registered:", modelNames);
+  let BambooPageModel;
+  try {
+    const { BambooPage } = await import("./src/models/BambooPage.mjs");
+    const { BambooDump } = await import("./src/models/BambooDump.mjs");
+    await BambooPage.init(); // створює індекси
+    await BambooDump.init();
+    console.log("🧩 Models registered:", Object.keys(mongoose.models));
+    BambooPageModel = BambooPage;
+  } catch (e) {
+    console.warn("Model init warning:", e?.message || e);
+  }
 
-  const { BambooPage } = await import("./src/models/BambooPage.mjs");
-  if (!BambooPage?.modelName || typeof BambooPage.find !== "function") {
+  if (!BambooPageModel?.modelName || typeof BambooPageModel.find !== "function") {
     throw new Error(
       "[fatal] BambooPage is not a real Mongoose model (modelName is null or find missing)."
     );

--- a/src/models/BambooPage.mjs
+++ b/src/models/BambooPage.mjs
@@ -1,4 +1,3 @@
-// src/models/BambooPage.mjs
 import mongoose from "mongoose";
 
 const BambooPageSchema = new mongoose.Schema(
@@ -11,10 +10,8 @@ const BambooPageSchema = new mongoose.Schema(
   { collection: "bamboo_pages", strict: false, minimize: false }
 );
 
-// унікальність пари key+pageIndex для апсерта
+// Унікальність пари key+pageIndex для апсерта
 BambooPageSchema.index({ key: 1, pageIndex: 1 }, { unique: true });
 
 export const BambooPage =
   mongoose.models.BambooPage || mongoose.model("BambooPage", BambooPageSchema);
-
-export default BambooPage;


### PR DESCRIPTION
## Summary
- enforce an explicit collection and unique compound index for BambooPage
- harden Bamboo export upsert logic and aggregation to rely solely on Mongoose
- add a Bamboo pages diagnostic route and initialize model indexes on startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d977f15c60832ba4e3a0317289dc76