### PR TITLE
Ensure Bamboo models initialize safely

### DIFF
--- a/src/models/BambooDump.mjs
+++ b/src/models/BambooDump.mjs
@@ -1,26 +1,21 @@
-import { mongoose } from "../db/mongoose.mjs";
+import mongoose from "mongoose";
 
-const Schema = new mongoose.Schema(
+const BambooDumpSchema = new mongoose.Schema(
   {
-    key: { type: String, required: true, index: true },
-    query: {},
-    pagesFetched: Number,
-    total: Number,
-    lastPage: Number,
-    pageSize: Number,
+    key: { type: String, required: true, unique: true, index: true },
+    query: { type: Object, default: {} },
+    pagesFetched: { type: Number, default: 0 },
+    total: { type: Number, default: 0 },
+    lastPage: { type: Number, default: null },
+    pageSize: { type: Number, default: 100 },
     updatedAt: { type: Date, default: Date.now, index: true },
   },
-  { collection: "bamboo_dump" }
+  {
+    collection: "bamboo_dump",
+    strict: false,
+    minimize: false,
+  }
 );
 
-Schema.index({ key: 1 }, { unique: true });
-
-const _Model =
-  (mongoose.models?.BambooDump) || mongoose.model("BambooDump", Schema);
-
-export const BambooDump = _Model;
-export default _Model;
-
-console.log("[model] BambooDump registered (has deleteOne)", {
-  hasDeleteOne: typeof BambooDump?.deleteOne === "function",
-});
+export const BambooDump =
+  mongoose.models.BambooDump || mongoose.model("BambooDump", BambooDumpSchema);

--- a/src/models/BambooPage.mjs
+++ b/src/models/BambooPage.mjs
@@ -7,11 +7,16 @@ const BambooPageSchema = new mongoose.Schema(
     items: { type: Array, default: [] },
     updatedAt: { type: Date, default: Date.now, index: true },
   },
-  { collection: "bamboo_pages", strict: false, minimize: false }
+  {
+    collection: "bamboo_pages",
+    strict: false,
+    minimize: false,
+  }
 );
 
-// Унікальність пари key+pageIndex для апсерта
+// Унікальність документів сторінок за ключем експорту + індекс сторінки
 BambooPageSchema.index({ key: 1, pageIndex: 1 }, { unique: true });
 
+// Експортуємо справжню модель (має .modelName, .find, .init тощо)
 export const BambooPage =
   mongoose.models.BambooPage || mongoose.model("BambooPage", BambooPageSchema);


### PR DESCRIPTION
## Summary
- convert BambooPage and BambooDump into proper reusable Mongoose models with explicit collections and defaults
- initialize Bamboo models after Mongo connection with graceful error handling and model diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da441de288832b9866eeb3718fb848