### PR TITLE
Refactor mongoose models and bamboo export fallbacks

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -67,28 +67,12 @@ async function bootstrap() {
   const { BambooPage } = await import("./src/models/BambooPage.mjs");
   const { CuratedCatalog } = await import("./src/models/CuratedCatalog.mjs");
 
-  // Хелпер перевірки «це реальна модель?»
-  const isModel = (m) =>
-    m && typeof m === "function" && m.modelName && typeof m.find === "function";
-
-  // Ініціалізуємо індекси де підтримується
+  // best-effort indexes (не падаємо, якщо щось)
   for (const m of [BambooDump, BambooPage, CuratedCatalog]) {
-    if (isModel(m) && typeof m.init === "function") {
-      try { await m.init(); } catch (e) { console.warn(`[model:init] ${m.modelName}:`, e?.message || e); }
-    }
+    if (m?.init) { try { await m.init(); } catch {} }
   }
 
-  const registered = Object.keys(mongooseDefault.models || {});
-  console.log("🧩 Models registered:", registered);
-
-  // Якщо якась модель все ще «не справжня» — лише попереджаємо, але не падаємо сервером
-  for (const [name, m] of Object.entries({ BambooDump, BambooPage, CuratedCatalog })) {
-    if (!isModel(m)) {
-      console.warn(`[model] ${name} is not a real Mongoose model — check export/import`);
-    } else {
-      console.log(`[model] ${name} OK (modelName=${m.modelName})`);
-    }
-  }
+  console.log("🧩 Models registered:", Object.keys(mongooseDefault.models || {}));
 
   // Імпортуємо роутери
   const { debugEnvRouter } = await import("./src/routes/debug-env.mjs");

--- a/src/models/CuratedCatalog.mjs
+++ b/src/models/CuratedCatalog.mjs
@@ -1,22 +1,14 @@
-import { mongoose } from "../db/mongoose.mjs";
+import mongoose from "mongoose";
 
-const Schema = new mongoose.Schema(
+const CuratedSchema = new mongoose.Schema(
   {
-    key: { type: String, required: true, index: true },
-    payload: {},
+    key: { type: String, required: true, unique: true, index: true },
+    groups: { type: Array, default: [] },
     updatedAt: { type: Date, default: Date.now, index: true },
   },
-  { collection: "curated_catalog" }
+  { collection: "curated_catalog", strict: false, minimize: false }
 );
 
-Schema.index({ key: 1 }, { unique: true });
+export const CuratedCatalog =
+  mongoose.models.CuratedCatalog || mongoose.model("CuratedCatalog", CuratedSchema);
 
-const _Model =
-  (mongoose.models?.CuratedCatalog) || mongoose.model("CuratedCatalog", Schema);
-
-export const CuratedCatalog = _Model;
-export default _Model;
-
-console.log("[model] CuratedCatalog registered (has findOne)", {
-  hasFindOne: typeof CuratedCatalog?.findOne === "function",
-});


### PR DESCRIPTION
## Summary
- replace the curated catalog stub with a real mongoose model definition
- load mongoose models after connecting and initialize their indexes without warnings
- rely solely on mongoose APIs in the bamboo export route for page upserts and saved item totals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daaa3b9a04832ba866804943688184