### PR TITLE
Ensure Bamboo dumps are persisted and add diagnostics

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -79,6 +79,7 @@ async function bootstrap() {
   const { debugModelRouter } = await import("./src/routes/debug-model.mjs");
   const { default: debugRouter } = await import("./src/routes/debug.mjs");
   const { bambooExportRouter } = await import("./src/routes/bamboo-export.mjs");
+  const { bambooDumpsRouter } = await import("./src/routes/bamboo-dumps.mjs");
   const { bambooItemsRouter } = await import("./src/routes/bamboo-items.mjs");
   const { bambooPagesRouter } = await import("./src/routes/bamboo-pages.mjs");
   const { bambooPeekRouter } = await import("./src/routes/bamboo-peek.mjs");
@@ -88,6 +89,7 @@ async function bootstrap() {
   app.use("/api", debugModelRouter);
   app.use("/api", debugRouter);
   app.use("/api", bambooExportRouter);
+  app.use("/api", bambooDumpsRouter);
   app.use("/api", bambooItemsRouter);
   app.use("/api", bambooPagesRouter);
   app.use("/api", bambooPeekRouter);

--- a/src/routes/bamboo-dumps.mjs
+++ b/src/routes/bamboo-dumps.mjs
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { BambooDump } from "../models/BambooDump.mjs";
+
+export const bambooDumpsRouter = Router();
+
+// GET /api/bamboo/dumps — останні 20 дампів
+bambooDumpsRouter.get("/bamboo/dumps", async (req, res) => {
+  try {
+    const dumps = await BambooDump.find({}, { key: 1, pagesFetched: 1, total: 1, lastPage: 1, pageSize: 1, updatedAt: 1 })
+      .sort({ updatedAt: -1 })
+      .limit(20)
+      .lean();
+
+    res.json({ ok: true, count: dumps.length, dumps });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e?.message || "dumps failed" });
+  }
+});


### PR DESCRIPTION
## Summary
- harden the Bamboo page upsert flow and guarantee BambooDump creation with logging
- ensure Bamboo export statistics use Mongoose helpers with resilient fallbacks
- add a diagnostic /api/bamboo/dumps endpoint and register it with the server

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db992774c4832b8285cea9af00c78a