### PR TITLE
Use native Mongo handles for bamboo export upserts

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -31,45 +31,30 @@ export function isMongoReady() {
 }
 
 /**
- * Повертає native-колекцію. Якщо конекшен ще не відкритий — чекає.
- * Таймаут очікування ~10с.
+ * Повертає native Db-інстанс, ініціалізуючи його за потреби.
  */
-export async function getNativeCollection(name) {
-  // якщо вже готово — повертаємо одразу
-  if (mongoose?.connection?.readyState === 1 && mongoose?.connection?.db) {
-    return mongoose.connection.db.collection(name);
+export function getNativeDb() {
+  const conn = mongoose.connection;
+  // 1 = connected
+  if (!conn || conn.readyState !== 1) {
+    throw new Error(`Mongo connection not connected (state=${conn?.readyState ?? "n/a"})`);
   }
+  if (conn.db) return conn.db;
 
-  // спроба дочекатися відкриття поточного конекшену
-  try {
-    // якщо є активний connectPromise — дочекаємося
-    if (connectPromise) {
-      await connectPromise;
-    } else if (mongoose?.connection?.asPromise) {
-      // для mongoose v7+
-      await mongoose.connection.asPromise();
-    } else {
-      // Фолбек: невеликий цикл очікування
-      const started = Date.now();
-      while (Date.now() - started < 10000) {
-        if (mongoose?.connection?.readyState === 1 && mongoose?.connection?.db) break;
-        await new Promise((r) => setTimeout(r, 200));
-      }
-    }
-  } catch (_) {
-    // ігноруємо — нижче ще раз перевіримо стан
+  // Ініціалізуємо db, якщо відсутній (Atlas/driver 6 інколи не виставляє його автоматично)
+  const client = conn.getClient?.();
+  const name = conn.name || process.env.MONGODB_DB_NAME || "test";
+  if (client && typeof client.db === "function") {
+    const db = client.db(name);
+    // збережемо, щоб наступні виклики були швидкі
+    conn.db = db;
+    return db;
   }
+  throw new Error("Mongo client db handle is not available");
+}
 
-  if (mongoose?.connection?.readyState === 1 && mongoose?.connection?.db) {
-    return mongoose.connection.db.collection(name);
-  }
-
-  // повертаємо інформативну помилку (але тепер її не будемо кидати з роутів)
-  const state = mongoose?.connection?.readyState ?? null;
-  const nameInfo = mongoose?.connection?.name ?? null;
-  const msg = `Mongo connection DB is not ready (state=${state}, name=${nameInfo})`;
-  const err = new Error(msg);
-  err.code = "MONGO_NOT_READY";
-  throw err;
+export function getNativeCollection(name) {
+  const db = getNativeDb();
+  return db.collection(name);
 }
 


### PR DESCRIPTION
## Summary
- expose a reliable native MongoDB handle via getNativeDb/getNativeCollection
- refactor the bamboo export upserts to use native updateOne with sanitized payloads
- guard the export endpoint until the Mongo connection is established

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce4d39f14832bb2690ace59538a2d