### PR TITLE
docs: clarify native mongo helpers

### DIFF
--- a/src/db/mongoose.mjs
+++ b/src/db/mongoose.mjs
@@ -4,6 +4,10 @@ export { default as mongoose } from "mongoose";
 
 let connectPromise = null;
 
+/**
+ * ПОВИННО бути викликано на старті (у вас вже є connectMongo).
+ * Тут змін не робимо, лише залишаємо як є.
+ */
 export async function connectMongo(uri, dbName) {
   const finalUri = uri || process.env.MONGODB_URI || process.env.DB_URL || process.env.MONGO_URL;
   if (!finalUri) {
@@ -31,7 +35,8 @@ export function isMongoReady() {
 }
 
 /**
- * Повертає native Db-інстанс, ініціалізуючи його за потреби.
+ * Надійно повертає native DB handle і кешує його в connection.db,
+ * навіть якщо драйвер/версія Mongoose не виставили його автоматично.
  */
 export function getNativeDb() {
   const conn = mongoose.connection;


### PR DESCRIPTION
## Summary
- document that the Mongo connection helper must be invoked at startup
- explain the reliability guarantees around the cached native database handle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e9c858fc832ba9fd843c11a25737