### PR TITLE
Fix native Mongo async bootstrap

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2,7 +2,7 @@
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
-import { connectMongo, mongoose } from "./src/db/mongoose.mjs";
+import { connectMongo } from "./src/db/mongoose.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
@@ -20,7 +20,13 @@ let served = false;
 for (const p of distCandidates) {
   try {
     const exists = await (async () => {
-      try { return (await import("node:fs/promises")).stat(p).then(s => s.isDirectory()).catch(() => false); } catch { return false; }
+      try {
+        const fs = await import("node:fs/promises");
+        const stat = await fs.stat(p);
+        return stat.isDirectory();
+      } catch {
+        return false;
+      }
     })();
     console.log(`🔎 DIST candidate: ${p} exists: ${exists}`);
     if (exists && !served) {
@@ -33,95 +39,89 @@ for (const p of distCandidates) {
 
 const PORT = process.env.PORT || 10000;
 
-// Старт з'єднання і роутів
-async function bootstrap() {
-  // ---- Mongo bootstrap with fallbacks ----
-  const mongoUri =
-    process.env.MONGODB_URI ||
-    process.env.DB_URL ||
-    process.env.MONGO_URL ||
-    "";
+const mongoUri =
+  process.env.MONGODB_URI ||
+  process.env.DB_URL ||
+  process.env.MONGO_URL ||
+  "";
 
-  const mongoDbName =
-    process.env.MONGODB_DB_NAME ||
-    process.env.DB_NAME ||
-    undefined;
+const mongoDbName =
+  process.env.MONGODB_DB_NAME ||
+  process.env.DB_NAME ||
+  undefined;
 
-  if (!mongoUri) {
-    throw new Error(
-      "Bootstrap failed: no Mongo URI found. Expected MONGODB_URI or DB_URL (or MONGO_URL)."
-    );
-  }
+if (!mongoUri) {
+  console.error(
+    "Bootstrap failed: no Mongo URI found. Expected MONGODB_URI or DB_URL (or MONGO_URL)."
+  );
+  process.exit(1);
+}
 
-  try {
-    const conn = await connectMongo(mongoUri, mongoDbName);
-    const name = conn?.name || mongoose?.connection?.name || "(unknown)";
-    console.log("Mongo connected:", name);
-  } catch (e) {
-    console.error("❌ Mongo connect failed at startup:", e?.message || e);
-    throw e;
-  }
+try {
+  const conn = await connectMongo(mongoUri, mongoDbName);
+  const connectedName = conn?.name || mongoDbName || "digi";
+  console.log(`Mongo connected: ${connectedName}`);
+} catch (e) {
+  console.error("❌ Mongo connect failed at startup:", e?.message || e);
+  process.exit(1);
+}
 
-  const { default: mongooseDefault } = await import("mongoose");
-  const { BambooDump } = await import("./src/models/BambooDump.mjs");
-  const { BambooPage } = await import("./src/models/BambooPage.mjs");
-  const { CuratedCatalog } = await import("./src/models/CuratedCatalog.mjs");
+const { default: mongooseDefault } = await import("mongoose");
+const { BambooDump } = await import("./src/models/BambooDump.mjs");
+const { BambooPage } = await import("./src/models/BambooPage.mjs");
+const { CuratedCatalog } = await import("./src/models/CuratedCatalog.mjs");
 
-  // best-effort indexes (не падаємо, якщо щось)
-  for (const m of [BambooDump, BambooPage, CuratedCatalog]) {
-    if (m?.init) { try { await m.init(); } catch {} }
-  }
-
-  console.log("🧩 Models registered:", Object.keys(mongooseDefault.models || {}));
-
-  // Імпортуємо роутери
-  const { debugEnvRouter } = await import("./src/routes/debug-env.mjs");
-  const { debugModelRouter } = await import("./src/routes/debug-model.mjs");
-  const { default: debugRouter } = await import("./src/routes/debug.mjs");
-  const { debugNativeRouter } = await import("./src/routes/debug-native.mjs");
-  const { bambooExportRouter } = await import("./src/routes/bamboo-export.mjs");
-  const { bambooDumpsRouter } = await import("./src/routes/bamboo-dumps.mjs");
-  const { bambooItemsRouter } = await import("./src/routes/bamboo-items.mjs");
-  const { bambooPagesRouter } = await import("./src/routes/bamboo-pages.mjs");
-  const { bambooPeekRouter } = await import("./src/routes/bamboo-peek.mjs");
-  const { bambooStatusRouter } = await import("./src/routes/bamboo-status.mjs");
-  const { curatedRouter } = await import("./src/routes/curated.mjs");
-  app.use("/api", debugEnvRouter);
-  app.use("/api", debugModelRouter);
-  app.use("/api", debugRouter);
-  app.use("/api", debugNativeRouter);
-  app.use("/api", bambooExportRouter);
-  app.use("/api", bambooDumpsRouter);
-  app.use("/api", bambooItemsRouter);
-  app.use("/api", bambooPagesRouter);
-  app.use("/api", bambooPeekRouter);
-  app.use("/api", bambooStatusRouter);
-  app.use("/api", curatedRouter);
-
-  app.listen(PORT, () => {
-    console.log(`Server on :${PORT}`);
-  });
-
-  // Auto-refresh curated cache on interval (optional)
-  if ((process.env.BAMBOO_AUTO_REFRESH_CRON || "disabled") === "enabled") {
-    const minutes = Math.max(5, parseInt(process.env.BAMBOO_AUTO_REFRESH_INTERVAL_MIN || "60", 10));
-    const currencies = (process.env.BAMBOO_AUTO_REFRESH_CURRENCIES || "USD,EUR,CAD,AUD").split(",").map(s=>s.trim());
-    const tick = async () => {
-      try {
-        const { buildCurated } = await import("./src/services/curate.mjs");
-        await buildCurated({ currencies });
-        console.log(`[auto-refresh] curated updated for ${currencies.join(",")}`);
-      } catch (e) {
-        console.warn("[auto-refresh] failed:", e?.message || e);
-      }
-    };
-    setInterval(tick, minutes * 60 * 1000);
-    tick();
+for (const m of [BambooDump, BambooPage, CuratedCatalog]) {
+  if (m?.init) {
+    try {
+      await m.init();
+    } catch {}
   }
 }
 
-bootstrap().catch(err => {
-  console.error('❌ Bootstrap failed:', err?.message || err);
-  process.exit(1);
+console.log("🧩 Models registered:", Object.keys(mongooseDefault.models || {}));
+
+const { debugEnvRouter } = await import("./src/routes/debug-env.mjs");
+const { debugModelRouter } = await import("./src/routes/debug-model.mjs");
+const { default: debugRouter } = await import("./src/routes/debug.mjs");
+const { debugNativeRouter } = await import("./src/routes/debug-native.mjs");
+const { bambooExportRouter } = await import("./src/routes/bamboo-export.mjs");
+const { bambooDumpsRouter } = await import("./src/routes/bamboo-dumps.mjs");
+const { bambooItemsRouter } = await import("./src/routes/bamboo-items.mjs");
+const { bambooPagesRouter } = await import("./src/routes/bamboo-pages.mjs");
+const { bambooPeekRouter } = await import("./src/routes/bamboo-peek.mjs");
+const { bambooStatusRouter } = await import("./src/routes/bamboo-status.mjs");
+const { curatedRouter } = await import("./src/routes/curated.mjs");
+
+app.use("/api", debugEnvRouter);
+app.use("/api", debugModelRouter);
+app.use("/api", debugRouter);
+app.use("/api", debugNativeRouter);
+app.use("/api", bambooExportRouter);
+app.use("/api", bambooDumpsRouter);
+app.use("/api", bambooItemsRouter);
+app.use("/api", bambooPagesRouter);
+app.use("/api", bambooPeekRouter);
+app.use("/api", bambooStatusRouter);
+app.use("/api", curatedRouter);
+
+app.listen(PORT, () => {
+  console.log(`Server on :${PORT}`);
 });
+
+if ((process.env.BAMBOO_AUTO_REFRESH_CRON || "disabled") === "enabled") {
+  const minutes = Math.max(5, parseInt(process.env.BAMBOO_AUTO_REFRESH_INTERVAL_MIN || "60", 10));
+  const currencies = (process.env.BAMBOO_AUTO_REFRESH_CURRENCIES || "USD,EUR,CAD,AUD").split(",").map(s => s.trim());
+  const tick = async () => {
+    try {
+      const { buildCurated } = await import("./src/services/curate.mjs");
+      await buildCurated({ currencies });
+      console.log(`[auto-refresh] curated updated for ${currencies.join(",")}`);
+    } catch (e) {
+      console.warn("[auto-refresh] failed:", e?.message || e);
+    }
+  };
+  setInterval(tick, minutes * 60 * 1000);
+  tick();
+}
 

--- a/src/routes/bamboo-export.mjs
+++ b/src/routes/bamboo-export.mjs
@@ -266,7 +266,7 @@ export async function sumSavedItemsByKey(key) {
 
 // ---------- upsert helper (native only) ----------
 async function upsertBambooPage(filter, pageDoc) {
-  const coll = getNativeCollection("bamboo_pages");
+  const coll = await getNativeCollection("bamboo_pages");
   const safeDoc = sanitizeForSet(pageDoc);
   await coll.updateOne(filter, { $set: safeDoc }, { upsert: true });
   return await coll.findOne(filter, { projection: { _id: 1, pageIndex: 1, updatedAt: 1 } });
@@ -410,7 +410,7 @@ bambooExportRouter.get("/bamboo/export.json", async (req, res) => {
         updatedAt: new Date(),
       };
       try {
-        const collDump = getNativeCollection("bamboo_dump");
+        const collDump = await getNativeCollection("bamboo_dump");
         await collDump.updateOne(
           { key },
           { $set: sanitizeForSet(dumpSet) },

--- a/src/routes/debug-native.mjs
+++ b/src/routes/debug-native.mjs
@@ -1,14 +1,14 @@
 // src/routes/debug-native.mjs
 import { Router } from "express";
 import mongoose from "mongoose";
-import { getNativeDb } from "../db/mongoose.mjs";
+import { getNativeDbAsync } from "../db/mongoose.mjs";
 
 export const debugNativeRouter = Router();
 
-debugNativeRouter.get("/debug/native", (req, res) => {
+debugNativeRouter.get("/debug/native", async (req, res) => {
   const conn = mongoose.connection;
   try {
-    const db = getNativeDb();
+    const db = await getNativeDbAsync();
     return res.json({
       ok: true,
       readyState: conn?.readyState ?? null,


### PR DESCRIPTION
## Summary
- add an async cached native MongoDB accessor and collection helper
- await native handles in bamboo export and debug routes
- defer router registration until after Mongo connection is established

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea1095806c832bacb57f8f1237a588